### PR TITLE
Add unlock steps for legacy android devices

### DIFF
--- a/v1/arale.json
+++ b/v1/arale.json
@@ -1,7 +1,7 @@
 {
   "name": "Meizu MX4",
   "codename": "arale",
-  "unlock": [],
+  "unlock": ["unlock"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -14,6 +14,11 @@
       "description": "Press and hold the volume down and power buttons until the phone reboots.",
       "image": "phone_power_down",
       "button": true
+    },
+    "unlock": {
+      "title": "Unlock",
+      "description": "If the device is running Android, it needs to be manually unlocked for the Installer to work. This is achieved by first installing a very old version of Canonical's Ubuntu Touch using an OEM tool, which is a manual process. Click the link below to find out more. If the device is already running Ubuntu Touch, you can simply ignore this message.",
+      "link": "https://docs.ubports.com/en/latest/userguide/install.html#install-on-legacy-android-devices"
     }
   },
   "operating_systems": [

--- a/v1/cooler.json
+++ b/v1/cooler.json
@@ -1,7 +1,7 @@
 {
   "name": "Bq Aquaris M10 HD",
   "codename": "cooler",
-  "unlock": ["unlock"],
+  "unlock": ["unlock", "confirm_model"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -19,6 +19,10 @@
       "title": "Unlock",
       "description": "If the device is running Android, it needs to be manually unlocked for the Installer to work. This is achieved by first installing a very old version of Canonical's Ubuntu Touch using an OEM tool, which is a manual process. Click the link below to find out more. If the device is already running Ubuntu Touch, you can simply ignore this message.",
       "link": "https://docs.ubports.com/en/latest/userguide/install.html#install-on-legacy-android-devices"
+    },
+    "confirm_model": {
+      "title": "Confirm your model",
+      "description": "Please double-check that your device is a Bq M10 HD (cooler). If you have the FHD version (frieza), you have to select that instead."
     }
   },
   "operating_systems": [

--- a/v1/cooler.json
+++ b/v1/cooler.json
@@ -1,7 +1,7 @@
 {
   "name": "Bq Aquaris M10 HD",
   "codename": "cooler",
-  "unlock": [],
+  "unlock": ["unlock"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -14,6 +14,11 @@
       "description": "Press and hold the volume up and power buttons until the phone reboots. Use the volume keys to select bootloader mode and confirm with the power button.",
       "image": "phone_power_up",
       "button": true
+    },
+    "unlock": {
+      "title": "Unlock",
+      "description": "If the device is running Android, it needs to be manually unlocked for the Installer to work. This is achieved by first installing a very old version of Canonical's Ubuntu Touch using an OEM tool, which is a manual process. Click the link below to find out more. If the device is already running Ubuntu Touch, you can simply ignore this message.",
+      "link": "https://docs.ubports.com/en/latest/userguide/install.html#install-on-legacy-android-devices"
     }
   },
   "operating_systems": [

--- a/v1/deb.json
+++ b/v1/deb.json
@@ -1,7 +1,7 @@
 {
   "name": "Nexus 7 2013 LTE",
   "codename": "deb",
-  "unlock": [],
+  "unlock": ["confirm_model"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -14,6 +14,10 @@
       "description": "With the device powered off, hold Volume Down + Power until the bootloader appears.",
       "image": "phone_power_down",
       "button": true
+    },
+    "confirm_model": {
+      "title": "Confirm your model",
+      "description": "Please double-check that your device is an LG Nexus 7 2013 LTE (deb). If you have the wifi-only version (flo), you have to select that instead. The 2012 version is not compatible."
     }
   },
   "operating_systems": [

--- a/v1/flo.json
+++ b/v1/flo.json
@@ -14,6 +14,10 @@
       "description": "With the device powered off, hold Volume Down + Power until the bootloader appears.",
       "image": "phone_power_down",
       "button": true
+    },
+    "confirm_model": {
+      "title": "Confirm your model",
+      "description": "Please double-check that your device is an LG Nexus 7 2013 WiFi (flo). If you have the LTE version (deb), you have to select that instead. The 2012 version is not compatible."
     }
   },
   "operating_systems": [

--- a/v1/flo.json
+++ b/v1/flo.json
@@ -1,7 +1,7 @@
 {
   "name": "Nexus 7 2013 WiFi",
   "codename": "flo",
-  "unlock": [],
+  "unlock": ["confirm_model"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",

--- a/v1/frieza.json
+++ b/v1/frieza.json
@@ -1,7 +1,7 @@
 {
   "name": "Bq Aquaris M10 FHD",
   "codename": "frieza",
-  "unlock": ["unlock"],
+  "unlock": ["unlock", "confirm_model"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -19,6 +19,10 @@
       "title": "Unlock",
       "description": "If the device is running Android, it needs to be manually unlocked for the Installer to work. This is achieved by first installing a very old version of Canonical's Ubuntu Touch using an OEM tool, which is a manual process. Click the link below to find out more. If the device is already running Ubuntu Touch, you can simply ignore this message.",
       "link": "https://docs.ubports.com/en/latest/userguide/install.html#install-on-legacy-android-devices"
+    },
+    "confirm_model": {
+      "title": "Confirm your model",
+      "description": "Please double-check that your device is a Bq M10 FHD (frieza). If you have the HD version (cooler), you have to select that instead."
     }
   },
   "operating_systems": [

--- a/v1/frieza.json
+++ b/v1/frieza.json
@@ -1,7 +1,7 @@
 {
   "name": "Bq Aquaris M10 FHD",
   "codename": "frieza",
-  "unlock": [],
+  "unlock": ["unlock"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -14,6 +14,11 @@
       "description": "Press and hold the volume up and power buttons until the phone reboots. Use the volume keys to select bootloader mode and confirm with the power button.",
       "image": "phone_power_up",
       "button": true
+    },
+    "unlock": {
+      "title": "Unlock",
+      "description": "If the device is running Android, it needs to be manually unlocked for the Installer to work. This is achieved by first installing a very old version of Canonical's Ubuntu Touch using an OEM tool, which is a manual process. Click the link below to find out more. If the device is already running Ubuntu Touch, you can simply ignore this message.",
+      "link": "https://docs.ubports.com/en/latest/userguide/install.html#install-on-legacy-android-devices"
     }
   },
   "operating_systems": [

--- a/v1/hammerhead.json
+++ b/v1/hammerhead.json
@@ -1,7 +1,7 @@
 {
   "name": "Nexus 5",
   "codename": "hammerhead",
-  "unlock": [],
+  "unlock": ["confirm_model"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -14,6 +14,10 @@
       "description": "Press and hold the volume down and power buttons until the phone reboots.",
       "image": "phone_power_down",
       "button": true
+    },
+    "confirm_model": {
+      "title": "Confirm your model",
+      "description": "Please double-check that your device is an LG Nexus 5 (hammerhead). The LG Nexus 5x (bullhead) is not compatible."
     }
   },
   "operating_systems": [

--- a/v1/krillin.json
+++ b/v1/krillin.json
@@ -1,7 +1,7 @@
 {
   "name": "Bq Aquaris E4.5",
   "codename": "krillin",
-  "unlock": [],
+  "unlock": ["unlock"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -14,6 +14,11 @@
       "description": "With the device turned off, hold the volume up and power button until the phone boots. Then use the volume up button to select fastboot/bootloader mode and confirm with volume down.",
       "image": "phone_power_up",
       "button": true
+    },
+    "unlock": {
+      "title": "Unlock",
+      "description": "If the device is running Android, it needs to be manually unlocked for the Installer to work. This is achieved by first installing a very old version of Canonical's Ubuntu Touch using an OEM tool, which is a manual process. Click the link below to find out more. If the device is already running Ubuntu Touch, you can simply ignore this message.",
+      "link": "https://docs.ubports.com/en/latest/userguide/install.html#install-on-legacy-android-devices"
     }
   },
   "operating_systems": [

--- a/v1/suzu.json
+++ b/v1/suzu.json
@@ -1,7 +1,7 @@
 {
   "name": "Sony Xperia X (F5121)",
   "codename": "suzu",
-  "unlock": [],
+  "unlock": ["confirm_model"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -20,6 +20,10 @@
       "description": "Power on the device.",
       "image": "phone_power_up",
       "button": true
+    },
+    "confirm_model": {
+      "title": "Confirm your model",
+      "description": "Please double-check that your device is a Sony Xperia X (F5121), the 32 GB version. The F5121 (64 GB) version is not compatible."
     }
   },
   "operating_systems": [

--- a/v1/turbo.json
+++ b/v1/turbo.json
@@ -1,7 +1,7 @@
 {
   "name": "Meizu Pro 5",
   "codename": "turbo",
-  "unlock": [],
+  "unlock": ["unlock"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -14,6 +14,11 @@
       "description": "Press and hold the volume down and power buttons until the phone reboots.",
       "image": "phone_power_down",
       "button": true
+    },
+    "unlock": {
+      "title": "Unlock",
+      "description": "If the device is running Android, it needs to be manually unlocked for the Installer to work. This is achieved by first installing a very old version of Canonical's Ubuntu Touch using an OEM tool, which is a manual process. Click the link below to find out more. If the device is already running Ubuntu Touch, you can simply ignore this message.",
+      "link": "https://docs.ubports.com/en/latest/userguide/install.html#install-on-legacy-android-devices"
     }
   },
   "operating_systems": [

--- a/v1/vegetahd.json
+++ b/v1/vegetahd.json
@@ -1,7 +1,7 @@
 {
   "name": "Bq Aquaris E5",
   "codename": "vegetahd",
-  "unlock": [],
+  "unlock": ["unlock"],
   "user_actions": {
     "recovery": {
       "title": "Reboot to Recovery",
@@ -14,6 +14,11 @@
       "description": "With the device turned off, hold the volume up and power button until the phone boots. Then use the volume up button to select fastboot/bootloader mode and confirm with volume down.",
       "image": "phone_power_up",
       "button": true
+    },
+    "unlock": {
+      "title": "Unlock",
+      "description": "If the device is running Android, it needs to be manually unlocked for the Installer to work. This is achieved by first installing a very old version of Canonical's Ubuntu Touch using an OEM tool, which is a manual process. Click the link below to find out more. If the device is already running Ubuntu Touch, you can simply ignore this message.",
+      "link": "https://docs.ubports.com/en/latest/userguide/install.html#install-on-legacy-android-devices"
     }
   },
   "operating_systems": [


### PR DESCRIPTION
Since the UBports Installer supports these starting with the next version, it's time to get these in there. Does not break compatibility with older versions of the installer.