### PR TITLE
suzu: Add support for the F5122 (Dual SIM) variant

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -4,6 +4,7 @@
   "nexus5": "hammerhead",
   "fairphone2": "FP2",
   "F5121": "suzu",
+  "F5122": "suzu",
   "PRO5": "turbo",
   "mx4": "arale",
   "Aquaris_E45": "krillin",

--- a/index.json
+++ b/index.json
@@ -11,6 +11,6 @@
   "mako": "Nexus 4",
   "oneplus3": "Oneplus 3(T)",
   "turbo": "Meizu Pro 5",
-  "suzu": "Sony Xperia X (F5121)",
+  "suzu": "Sony Xperia X (F5121 & F5122)",
   "vegetahd": "Bq Aquaris E5"
 }

--- a/v1/suzu.json
+++ b/v1/suzu.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sony Xperia X (F5121)",
+  "name": "Sony Xperia X (F5121 & F5122)",
   "codename": "suzu",
   "unlock": ["confirm_model"],
   "user_actions": {
@@ -23,7 +23,7 @@
     },
     "confirm_model": {
       "title": "Confirm your model",
-      "description": "Please double-check that your device is a Sony Xperia X (F5121), the 32 GB version. The F5121 (64 GB) version is not compatible."
+      "description": "Please double-check that your device is a Sony Xperia X (F5121 or F5122)."
     }
   },
   "operating_systems": [


### PR DESCRIPTION
Due to recent changes in the Halium portion of the suzu port we now
support the F5122 variant of the Xperia X with the same image.