### PR TITLE
suzu: Update recovery checksum

### DIFF
--- a/v1/suzu.json
+++ b/v1/suzu.json
@@ -67,7 +67,7 @@
           "files": [
             {
               "url": "http://cdimage.ubports.com/devices/halium-unlocked-recovery_suzu.img",
-              "checksum": "1fd576f4685164971bf24f194d2a684fa7081616778fef7c882ed7345a1b8949"
+              "checksum": "d230df1a9d4d5d8e92232ec272e365996ef5a77edb60aaddbfcd5aa97e058dc1"
             }
           ]
         },


### PR DESCRIPTION
The new recovery contains the fix for the SD card
locking up the recovery initialization at startup.