### PR TITLE
Remove osx and node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ cache:
   - node_modules
 matrix:
   include:
-  - os: osx
   - os: linux
 node_js:
-  - "8"
-  - "10"
   - "12"
 script: "npm run-script validate:index && npm run-script validate:aliases && npm run-script validate:devices"


### PR DESCRIPTION
Since we only use this to validate json, there is no need to do it on more then one type of machine.