### PR TITLE
Flash manually downloaded OEM binaries on Suzu

### DIFF
--- a/v1/suzu.json
+++ b/v1/suzu.json
@@ -3,6 +3,7 @@
   "codename": "suzu",
   "unlock": ["confirm_model", "upgrade_android"],
   "user_actions": {
+    
     "recovery": {
       "title": "Reboot to Recovery",
       "description": "With the device powered off, hold Volume Down + Power.",
@@ -61,6 +62,19 @@
       "prerequisites": [],
       "steps": [
         {
+          "type": "manual_download",
+          "condition": {"var": "bootstrap", "value": true},
+          "group": "firmware",
+          "file": {
+            "name": "SW_binaries_for_Xperia_AOSP_N_MR1_5.7_r1_v08_loire.img",
+            "url": "https://developer.sony.com/file/download/software-binaries-for-aosp-nougat-android-7-1-kernel-4-4-loire/",
+            "checksum": {
+              "sum": "38fe0b6a72f4f2373529f29b12cba010a987cb3fa9417aebd7e3279eeea0798e",
+              "algorithm": "sha256"
+            }
+          }
+        },
+        {
           "type": "download",
           "condition": {"var": "bootstrap", "value": true},
           "group": "firmware",
@@ -76,6 +90,23 @@
           "condition": {"var": "bootstrap", "value": true},
           "to_state": "bootloader",
           "fallback_user_action": "bootloader"
+        },
+        {
+          "type": "fastboot:flash",
+          "condition": {"var": "bootstrap", "value": true},
+          "flash": [
+            {
+              "partition": "oem",
+              "file": "SW_binaries_for_Xperia_AOSP_N_MR1_5.7_r1_v08_loire.img",
+              "group": "firmware",
+              "raw": true
+            }
+          ]
+        },
+        {
+          "type": "fastboot:erase",
+          "condition": {"var": "bootstrap", "value": true},
+          "partition": "system"
         },
         {
           "type": "fastboot:flash",

--- a/v1/suzu.json
+++ b/v1/suzu.json
@@ -92,21 +92,19 @@
           "fallback_user_action": "bootloader"
         },
         {
-          "type": "fastboot:flash",
+          "type": "fastboot:erase",
           "condition": {"var": "bootstrap", "value": true},
-          "flash": [
-            {
-              "partition": "oem",
-              "file": "SW_binaries_for_Xperia_AOSP_N_MR1_5.7_r1_v08_loire.img",
-              "group": "firmware",
-              "raw": true
-            }
-          ]
+          "partition": "system"
         },
         {
           "type": "fastboot:erase",
           "condition": {"var": "bootstrap", "value": true},
-          "partition": "system"
+          "partition": "cache"
+        },
+        {
+          "type": "fastboot:erase",
+          "condition": {"var": "wipe", "value": true},
+          "partition": "userdata"
         },
         {
           "type": "fastboot:flash",
@@ -122,18 +120,13 @@
               "partition": "recovery",
               "file": "halium-unlocked-recovery_suzu.img",
               "group": "firmware"
+            },
+            {
+              "partition": "oem",
+              "file": "SW_binaries_for_Xperia_AOSP_N_MR1_5.7_r1_v08_loire.img",
+              "group": "firmware"
             }
           ]
-        },
-        {
-          "type": "fastboot:erase",
-          "condition": {"var": "bootstrap", "value": true},
-          "partition": "cache"
-        },
-        {
-          "type": "fastboot:erase",
-          "condition": {"var": "wipe", "value": true},
-          "partition": "userdata"
         },
         {
           "type": "fastboot:reboot",

--- a/v1/suzu.json
+++ b/v1/suzu.json
@@ -3,7 +3,6 @@
   "codename": "suzu",
   "unlock": ["confirm_model", "upgrade_android"],
   "user_actions": {
-    
     "recovery": {
       "title": "Reboot to Recovery",
       "description": "With the device powered off, hold Volume Down + Power.",


### PR DESCRIPTION
Updates suzu.json config to make use of new manual_download functionality and flash in a working order. Fixes #37 