### PR TITLE
Add msm8996 alias for oneplus3

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -13,6 +13,7 @@
   "Aquaris_E5": "vegetahd",
   "Aquaris_M10HD": "cooler",
   "Aquaris_M10FHD": "frieza",
+  "msm8996": "oneplus3",
   "OnePlus3": "oneplus3",
   "OnePlus3T": "oneplus3",
   "F8131": "dora",


### PR DESCRIPTION
As reported in the supergroup, the oneplus 3 t may introduce itself as msm8996 if detected via fastboot getvar. it was to be expected that we would have to add new aliases, but this is a little annoying, because msm8996 is not a device id, but the name of the chipset. if we have multiple devices with the same chipset and they all don't set this var properly, we'll have trouble and suffering. Let's add this anyways for now, if we do get duplicates, we'll implement a UI to prompt the user to select the right device. For now, this can be merged.