### PR TITLE
Add Fxtec Pro1 configuration

### DIFF
--- a/index.json
+++ b/index.json
@@ -22,5 +22,6 @@
   "karin": "Sony Xperia Z4 Tablet (SGP771 & SGP712)",
   "santoni": "Xiaomi Redmi 4X",
   "sargo": "Google Pixel 3a (sargo)",
-  "oneplus2": "Oneplus 2"
+  "oneplus2": "Oneplus 2",
+  "pro1": "F(x)tec Pro1"
 }

--- a/v1/pro1.json
+++ b/v1/pro1.json
@@ -1,0 +1,125 @@
+{
+  "name": "F(x)tec Pro1",
+  "codename": "pro1",
+  "unlock": ["unlock"],
+  "user_actions": {
+    "unlock": {
+      "title": "OEM unlock",
+      "description": "If you haven't done so already, make sure to OEM unlock your device first.",
+      "link": "https://source.android.com/devices/bootloader/locking_unlocking#unlocking-bootloader"
+    },
+    "bootloader": {
+      "title": "Reboot to Bootloader",
+      "description": "With the device powered off, press and hold the volume down and power buttons until the screen turns on. It should show a menu selection screen.",
+      "image": "phone_power_down",
+      "button": true
+    },
+    "recovery": {
+      "title": "Reboot to Recovery",
+      "description": "With the device still at the 'Fastboot Mode' screen (if not, power off the device and press and hold volume down and power buttons until the screen turns on), select the 'Recovery Mode' option by using the volume buttons and press the power button to enter.",
+      "image": "phone_power_down",
+      "button": true
+    }
+  },
+  "operating_systems": [
+    {
+      "name": "Ubuntu Touch",
+      "sanity_check": "Are you sure?",
+      "options": [
+        {
+          "var": "channel",
+          "name": "Channel",
+          "tooltip": "The release channel",
+          "link": "https://docs.ubports.com/en/latest/about/process/release-schedule.html",
+          "type": "select",
+          "remote_values": { "type": "systemimagechannels" }
+        },
+        {
+          "var": "wipe",
+          "name": "Wipe Userdata",
+          "tooltip": "Wipe personal data",
+          "type": "checkbox"
+        },
+        {
+          "var": "bootstrap",
+          "name": "Bootstrap",
+          "tooltip": "Flash system partitions using fastboot",
+          "type": "checkbox",
+          "value": true
+        }
+      ],
+      "prerequisites": [],
+      "steps": [
+        {
+          "type": "download",
+          "condition": {"var": "bootstrap", "value": true},
+          "group": "firmware",
+          "files": [
+            {
+              "url": "https://cdimage.ubports.com/devices/pro1/boot.img",
+              "checksum": {
+                "sum": "2204c2478854d4dfd1bb16fae2651f80ae07f4af4452eb4c0ff9bbc6ee3f6414",
+                "algorithm": "sha256"
+              }
+            },
+            {
+              "url": "https://raw.githubusercontent.com/rubencarneiro/rubencarneiro.io/main/assets/downloads/pro1/splash.img",
+              "checksum": {
+                "sum": "1446ae64f7fcbe17c684706d9f37e911807cf14e4b5c10a6e3b6398fc8777ee6",
+                "algorithm": "sha256"
+              }
+            }
+          ]
+        },
+        {
+          "type": "adb:reboot",
+          "condition": {"var": "bootstrap", "value": true},
+          "to_state": "bootloader",
+          "fallback_user_action": "bootloader"
+        },
+        {
+          "type": "fastboot:flash",
+          "condition": {"var": "bootstrap", "value": true},
+          "flash": [
+            {
+              "partition": "boot",
+              "file": "boot.img",
+              "group": "firmware"
+            },
+            {
+              "partition": "splash",
+              "file": "splash.img",
+              "group": "firmware"
+            }
+          ]
+        },
+        {
+          "type": "fastboot:format",
+          "condition": {"var": "wipe", "value": true},
+          "partition": "userdata",
+          "partitionType": "ext4"
+        },
+        {
+          "type": "user_action",
+          "condition": {"var": "bootstrap", "value": true},
+          "action": "recovery"
+        },
+        {
+          "type": "adb:reboot",
+          "condition": {"var": "bootstrap", "value": false},
+          "to_state": "recovery",
+          "fallback_user_action": "recovery"
+        },
+        {
+          "type": "systemimage"
+        },
+        {
+          "type": "adb:reboot",
+          "to_state": "recovery",
+          "fallback_user_action": "recovery"
+        }
+      ],
+      "slideshow": []
+    }
+  ]
+}


### PR DESCRIPTION
This is a port of Ubuntu Touch to the Fxtec Pro1. It installs and boot perfectly fine.

CC: @NotKit @NeoTheThird 

EDIT: Is it possible for us to have the boot.img on cdimages? That'd be nice as GitLab tends to delete artifacts.