### PR TITLE
sargo: Remove slot selection

### DIFF
--- a/v1/sargo.json
+++ b/v1/sargo.json
@@ -95,10 +95,6 @@
           "fallback_user_action": "bootloader"
         },
         {
-          "type": "fastboot:set_active",
-          "slot": "b"
-        },
-        {
           "type": "fastboot:flash",
           "condition": { "var": "bootstrap", "value": true },
           "flash": [

--- a/v2/devices/sargo.yml
+++ b/v2/devices/sargo.yml
@@ -79,9 +79,6 @@ operating_systems:
           var: "bootstrap"
           value: true
       - actions:
-          - fastboot:set_active:
-              slot: "b"
-      - actions:
           - fastboot:flash:
               partitions:
                 - partition: "boot"


### PR DESCRIPTION
Turns out that some devices have their primary boot slot
set to 'a' after a factory image installation, so revert
the use of slot selection altogether.