### PR TITLE
Move remaining devices to static hosting

### DIFF
--- a/v1/angler.json
+++ b/v1/angler.json
@@ -88,9 +88,9 @@
           "group": "firmware",
           "files": [
             {
-              "url": "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-angler/14/artifact/halium-unlocked-recovery_angler.img",
+              "url": "https://cdimage.ubports.com/devices/angler/halium-unlocked-recovery_angler.img",
               "checksum": {
-                "sum": "32d73944c4d5d2f6fb6f7f06b0a3bec1e9509fbe2c6e5965453c1982facde38d",
+                "sum": "9fb583720bd6a1ecbb1d6ce9c0714b49f3f82f2c00c51a0f6260e247d4bad288",
                 "algorithm": "sha256"
               }
             }

--- a/v1/dora.json
+++ b/v1/dora.json
@@ -66,9 +66,9 @@
           "group": "firmware",
           "files": [
             {
-              "url": "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-dora/9/artifact/halium-unlocked-recovery_dora.img",
+              "url": "https://cdimage.ubports.com/devices/dora/halium-unlocked-recovery_dora.img",
               "checksum": {
-                "sum": "069cf56a6b3251d31e253bf308a76f456400c21abfbc7e1850475fbed1f810cb",
+                "sum": "bbc74ef50b5f7b87aeed5c338999e9c3b546a7b63c32fd81d7b6978c93a3416e",
                 "algorithm": "sha256"
               }
             }

--- a/v1/kagura.json
+++ b/v1/kagura.json
@@ -65,9 +65,9 @@
           "group": "firmware",
           "files": [
             {
-              "url": "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-kagura/6/artifact/halium-unlocked-recovery_kagura.img",
+              "url": "https://cdimage.ubports.com/devices/kagura/halium-unlocked-recovery_kagura.img",
               "checksum": {
-                "sum": "c51f82c893d053965663140f9f8ccb15e0c80a01ac3a1a76e81ac49105ee978e",
+                "sum": "37ea6d5f374b02dc70595177e5e162738a9bf967329152c9441746ff388a6fad",
                 "algorithm": "sha256"
               }
             }

--- a/v1/kugo.json
+++ b/v1/kugo.json
@@ -66,9 +66,9 @@
           "group": "firmware",
           "files": [
             {
-              "url": "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-kugo/129/artifact/halium-unlocked-recovery_kugo.img",
+              "url": "https://cdimage.ubports.com/devices/kugo/halium-unlocked-recovery_kugo.img",
               "checksum": {
-                "sum": "e0ab1aae3a18c33a6fe92fdcfc40ad87071296a3fcf7185dcdd355a963b7080e",
+                "sum": "db070dcca99cf70771b2c95b30655c2073d0fe714971aa13263b507bd4614ac1",
                 "algorithm": "sha256"
               }
             }

--- a/v1/oneplus2.json
+++ b/v1/oneplus2.json
@@ -85,9 +85,9 @@
           "group": "firmware",
           "files": [
             {
-              "url": "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-oneplus2/2/artifact/halium-unlocked-recovery_oneplus2.img",
+              "url": "https://cdimage.ubports.com/devices/oneplus2/halium-unlocked-recovery_oneplus2.img",
               "checksum": {
-                "sum": "528ec709b0735a699484d0c748350a6c260ab8b8ae587395fe4a9dc16818c3be",
+                "sum": "460264723cf414b3dcfd4f0d8a781007772d1811957d6d22d712ed1fbd7f1523",
                 "algorithm": "sha256"
               }
             },

--- a/v1/santoni.json
+++ b/v1/santoni.json
@@ -71,16 +71,16 @@
           "group": "firmware",
           "files": [
             {
-              "url": "https://ci.ubports.com/view/Device%20Compatibility%20Images/job/Device%20Compatibility%20Images/job/halium-santoni/196/artifact/halium-unlocked-recovery_santoni.img",
+              "url": "https://cdimage.ubports.com/devices/santoni/halium-unlocked-recovery_santoni.img",
               "checksum": {
-                "sum": "25798584952f29273d3ec2ebf63e7551db26f48e447493461627172330d616a5",
+                "sum": "f7826ebba7460117fb1aa43f37b3e432a943741a04a6d70cf633d7b8ccd7a582",
                 "algorithm": "sha256"
               }
             },
             {
-              "url": "https://ci.ubports.com/view/Device%20Compatibility%20Images/job/Device%20Compatibility%20Images/job/halium-santoni/196/artifact/halium-boot_santoni.img",
+              "url": "https://cdimage.ubports.com/devices/santoni/halium-boot_santoni.img",
               "checksum": {
-                "sum": "bb8f5aa0d3f6f9e406cda3549764441379d9f54ff770b44218e5f59c65700884",
+                "sum": "ab372e4ee9da5dfb8f73ae5509710411861947a2cac01080a5b35d907f272870",
                 "algorithm": "sha256"
               }
             },

--- a/v1/trlte.json
+++ b/v1/trlte.json
@@ -53,7 +53,11 @@
           "group": "firmware",
           "files": [
             {
-              "url": "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-samsung_trlte/lastSuccessfulBuild/artifact/halium-unlocked-recovery_trlte.img"
+              "url": "https://cdimage.ubports.com/devices/trlte/halium-unlocked-recovery_trlte.img",
+              "checksum": {
+                "sum": "6e09e581fef7aa30fef50d289e415f2e8c963573db3fcaa0cd00e357efb53202",
+                "algorithm": "sha256"
+              }
             }
           ]
         },

--- a/v1/trltespr.json
+++ b/v1/trltespr.json
@@ -53,7 +53,11 @@
           "group": "firmware",
           "files": [
             {
-              "url": "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-samsung_trltespr/lastSuccessfulBuild/artifact/halium-unlocked-recovery_trltespr.img"
+              "url": "https://cdimage.ubports.com/devices/trltespr/halium-unlocked-recovery_trltespr.img",
+              "checksum": {
+                "sum": "db6c1f3366a8116b1335abcb6bdf1b69301499ee1bfd69200aa03f7122f47149",
+                "algorithm": "sha256"
+              }
             }
           ]
         },

--- a/v1/trltetmo.json
+++ b/v1/trltetmo.json
@@ -53,7 +53,11 @@
           "group": "firmware",
           "files": [
             {
-              "url": "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-samsung_trltetmo/lastSuccessfulBuild/artifact/halium-unlocked-recovery_trltetmo.img"
+              "url": "https://cdimage.ubports.com/devices/trltetmo/halium-unlocked-recovery_trltetmo.img",
+              "checksum": {
+                "sum": "af53ba5328149dfac997e7960364a700a15d97b194c480f528794a9ed1a9e724",
+                "algorithm": "sha256"
+              }
             }
           ]
         },

--- a/v2/devices/angler.yml
+++ b/v2/devices/angler.yml
@@ -77,9 +77,9 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-angler/14/artifact/halium-unlocked-recovery_angler.img"
+                - url: "https://cdimage.ubports.com/devices/angler/halium-unlocked-recovery_angler.img"
                   checksum:
-                    sum: "32d73944c4d5d2f6fb6f7f06b0a3bec1e9509fbe2c6e5965453c1982facde38d"
+                    sum: "9fb583720bd6a1ecbb1d6ce9c0714b49f3f82f2c00c51a0f6260e247d4bad288"
                     algorithm: "sha256"
         condition:
           var: "bootstrap"

--- a/v2/devices/dora.yml
+++ b/v2/devices/dora.yml
@@ -60,9 +60,9 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-dora/9/artifact/halium-unlocked-recovery_dora.img"
+                - url: "https://cdimage.ubports.com/devices/dora/halium-unlocked-recovery_dora.img"
                   checksum:
-                    sum: "069cf56a6b3251d31e253bf308a76f456400c21abfbc7e1850475fbed1f810cb"
+                    sum: "bbc74ef50b5f7b87aeed5c338999e9c3b546a7b63c32fd81d7b6978c93a3416e"
                     algorithm: "sha256"
         condition:
           var: "bootstrap"

--- a/v2/devices/kagura.yml
+++ b/v2/devices/kagura.yml
@@ -59,9 +59,9 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-kagura/6/artifact/halium-unlocked-recovery_kagura.img"
+                - url: "https://cdimage.ubports.com/devices/kagura/halium-unlocked-recovery_kagura.img"
                   checksum:
-                    sum: "c51f82c893d053965663140f9f8ccb15e0c80a01ac3a1a76e81ac49105ee978e"
+                    sum: "37ea6d5f374b02dc70595177e5e162738a9bf967329152c9441746ff388a6fad"
                     algorithm: "sha256"
         condition:
           var: "bootstrap"

--- a/v2/devices/kugo.yml
+++ b/v2/devices/kugo.yml
@@ -59,9 +59,9 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-kugo/129/artifact/halium-unlocked-recovery_kugo.img"
+                - url: "https://cdimage.ubports.com/devices/kugo/halium-unlocked-recovery_kugo.img"
                   checksum:
-                    sum: "e0ab1aae3a18c33a6fe92fdcfc40ad87071296a3fcf7185dcdd355a963b7080e"
+                    sum: "db070dcca99cf70771b2c95b30655c2073d0fe714971aa13263b507bd4614ac1"
                     algorithm: "sha256"
         condition:
           var: "bootstrap"

--- a/v2/devices/oneplus2.yml
+++ b/v2/devices/oneplus2.yml
@@ -76,9 +76,9 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-oneplus2/2/artifact/halium-unlocked-recovery_oneplus2.img"
+                - url: "https://cdimage.ubports.com/devices/oneplus2/halium-unlocked-recovery_oneplus2.img"
                   checksum:
-                    sum: "528ec709b0735a699484d0c748350a6c260ab8b8ae587395fe4a9dc16818c3be"
+                    sum: "460264723cf414b3dcfd4f0d8a781007772d1811957d6d22d712ed1fbd7f1523"
                     algorithm: "sha256"
                 - url: "https://raw.githubusercontent.com/rubencarneiro/rubencarneiro.io/main/assets/downloads/oneplus2/logo.bin"
                   checksum:

--- a/v2/devices/santoni.yml
+++ b/v2/devices/santoni.yml
@@ -63,13 +63,13 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://ci.ubports.com/view/Device%20Compatibility%20Images/job/Device%20Compatibility%20Images/job/halium-santoni/196/artifact/halium-unlocked-recovery_santoni.img"
+                - url: "https://cdimage.ubports.com/devices/santoni/halium-unlocked-recovery_santoni.img"
                   checksum:
-                    sum: "25798584952f29273d3ec2ebf63e7551db26f48e447493461627172330d616a5"
+                    sum: "f7826ebba7460117fb1aa43f37b3e432a943741a04a6d70cf633d7b8ccd7a582"
                     algorithm: "sha256"
-                - url: "https://ci.ubports.com/view/Device%20Compatibility%20Images/job/Device%20Compatibility%20Images/job/halium-santoni/196/artifact/halium-boot_santoni.img"
+                - url: "https://cdimage.ubports.com/devices/santoni/halium-boot_santoni.img"
                   checksum:
-                    sum: "bb8f5aa0d3f6f9e406cda3549764441379d9f54ff770b44218e5f59c65700884"
+                    sum: "ab372e4ee9da5dfb8f73ae5509710411861947a2cac01080a5b35d907f272870"
                     algorithm: "sha256"
                 - url: "https://github.com/ubports-santoni/android_device_xiaomi_santoni/raw/e7f3940a66166c756041cbf8fc55f88ab5f37821/ut-miscs/splash.img"
                   checksum:

--- a/v2/devices/trlte.yml
+++ b/v2/devices/trlte.yml
@@ -50,7 +50,10 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-samsung_trlte/lastSuccessfulBuild/artifact/halium-unlocked-recovery_trlte.img"
+                - url: "https://cdimage.ubports.com/devices/trlte/halium-unlocked-recovery_trlte.img"
+                  checksum:
+                    sum: "6e09e581fef7aa30fef50d289e415f2e8c963573db3fcaa0cd00e357efb53202"
+                    algorithm: "sha256"
       - actions:
           - adb:reboot:
               to_state: "bootloader"

--- a/v2/devices/trltespr.yml
+++ b/v2/devices/trltespr.yml
@@ -51,7 +51,10 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-samsung_trltespr/lastSuccessfulBuild/artifact/halium-unlocked-recovery_trltespr.img"
+                - url: "https://cdimage.ubports.com/devices/trltespr/halium-unlocked-recovery_trltespr.img"
+                  checksum:
+                    sum: "db6c1f3366a8116b1335abcb6bdf1b69301499ee1bfd69200aa03f7122f47149"
+                    algorithm: "sha256"
       - actions:
           - adb:reboot:
               to_state: "bootloader"

--- a/v2/devices/trltetmo.yml
+++ b/v2/devices/trltetmo.yml
@@ -50,7 +50,10 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://ci.ubports.com/job/Device%20Compatibility%20Images/job/halium-samsung_trltetmo/lastSuccessfulBuild/artifact/halium-unlocked-recovery_trltetmo.img"
+                - url: "https://cdimage.ubports.com/devices/trltetmo/halium-unlocked-recovery_trltetmo.img"
+                  checksum:
+                    sum: af53ba5328149dfac997e7960364a700a15d97b194c480f528794a9ed1a9e724
+                    algorithm: "sha256"
       - actions:
           - adb:reboot:
               to_state: "bootloader"


### PR DESCRIPTION
All of the jobs that were linked to are no longer enabled. Rather than moving to new builds on the CI server which could change over time, use the static cdimage server instead.

This requires testing:

- [ ] Google / Huawei Nexus 6P
- [ ] Sony Xperia X Performance
- [ ] Sony Xperia XZ
- [ ] Sony Xperia X Compact
- [x] OnePlus 2
- [ ] Xiaomi Redmi 4X
- [ ] Samsung Galaxy Note 4