### PR TITLE
yggdrasil: Fix Volla OS flashing issue

### DIFF
--- a/v1/yggdrasil.json
+++ b/v1/yggdrasil.json
@@ -194,11 +194,6 @@
               "partition": "recovery",
               "file": "twrp.img",
               "group": "firmware"
-            },
-            {
-              "partition": "boot",
-              "file": "unpacked/boot.img",
-              "group": "VollaOS"
             }
           ]
         },

--- a/v2/devices/yggdrasil.yml
+++ b/v2/devices/yggdrasil.yml
@@ -176,9 +176,6 @@ operating_systems:
                 - partition: "recovery"
                   file: "twrp.img"
                   group: "firmware"
-                - partition: "boot"
-                  file: "unpacked/boot.img"
-                  group: "VollaOS"
         condition:
           var: "install_twrp"
           value: true


### PR DESCRIPTION
Flashing the `boot.img` inside the Android flashable zip is not needed as this is already done by the updater-script while it is flashed in recovery mode on the device.

Fixes https://github.com/ubports/ubports-installer/issues/1620.
Fixes https://github.com/ubports/ubports-installer/issues/1712.