### PR TITLE
configs: Initial support for Google Pixel 3a XL

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -31,5 +31,6 @@
   "N910P": "trltespr",
   "N910T": "trltetmo",
   "N910V": "trltespr",
-  "N910W8": "trltetmo"
+  "N910W8": "trltetmo",
+  "bonito": "sargo"
 }

--- a/v1/sargo.json
+++ b/v1/sargo.json
@@ -1,5 +1,5 @@
 {
-  "name": "Google Pixel 3a",
+  "name": "Google Pixel 3a/3a XL",
   "codename": "sargo",
   "unlock": ["unlock", "downgrade_android", "support"],
   "user_actions": {
@@ -27,7 +27,7 @@
     },
     "support": {
       "title": "Support",
-      "description": "For details about Ubuntu Touch support for the Pixel 3a, please head over to the UBports forum thread.",
+      "description": "For details about Ubuntu Touch support for the Pixel 3a & 3a XL, please head over to the UBports forum thread.",
       "link": "https://forums.ubports.com/topic/4621/google-pixel-3a-sargo"
     }
   },

--- a/v2/devices/sargo.yml
+++ b/v2/devices/sargo.yml
@@ -1,4 +1,4 @@
-name: "Google Pixel 3a"
+name: "Google Pixel 3a/3a XL"
 codename: "sargo"
 formfactor: "phone"
 aliases: []
@@ -20,7 +20,7 @@ user_actions:
     link: "https://developers.google.com/android/images#sargo"
   support:
     title: "Support"
-    description: "For details about Ubuntu Touch support for the Pixel 3a, please head over to the UBports forum thread."
+    description: "For details about Ubuntu Touch support for the Pixel 3a & 3a XL, please head over to the UBports forum thread."
     link: "https://forums.ubports.com/topic/4621/google-pixel-3a-sargo"
 unlock:
   - "downgrade_android"


### PR DESCRIPTION
Add an alias from 'bonito' to 'sargo' as both the non-XL & XL variants
can use the same system, kernel and dtbo images.
Also adapt the hints to reference the XL variant.