### PR TITLE
onclite: add Xiaomi Redmi 7

### DIFF
--- a/v2/devices/onclite.yml
+++ b/v2/devices/onclite.yml
@@ -1,0 +1,147 @@
+name: "Xiaomi Redmi 7"
+codename: "onclite"
+formfactor: "phone"
+aliases:
+  - "onc"
+doppelgangers: []
+user_actions:
+  recovery:
+    title: "Reboot to Recovery"
+    description: "With the device powered off, hold Volume Up + Power."
+    image: "phone_power_up"
+    button: true
+  bootloader:
+    title: "Reboot to Bootloader"
+    description: "With the device powered off, hold Volume Down + Power."
+    image: "phone_power_down"
+    button: true
+  boot:
+    title: "Boot the device"
+    description: "Power on the device."
+    image: "phone_power_up"
+    button: true
+  confirm_model:
+    title: "Confirm your model"
+    description: "Please double-check that your device is a Xiaomi Redmi 7 (onc/onclite)."
+  unlock:
+    title: "OEM unlock"
+    description: "If you haven't done so already, make sure to OEM unlock your device first."
+    link: "https://en.miui.com/unlock/"
+unlock:
+  - "confirm_model"
+  - "unlock"
+handlers:
+  bootloader_locked:
+    actions:
+      - fastboot:oem_unlock:
+operating_systems:
+  - name: "Ubuntu Touch"
+    options:
+      - var: "channel"
+        name: "Channel"
+        tooltip: "The release channel"
+        link: "https://docs.ubports.com/en/latest/about/process/release-schedule.html"
+        type: "select"
+        remote_values:
+          systemimage:channels:
+      - var: "wipe"
+        name: "Wipe Userdata"
+        tooltip: "Wipe personal data (required if the previously installed OS is Android, MIUI or LineageOS)"
+        type: "checkbox"
+      - var: "bootstrap"
+        name: "Bootstrap"
+        tooltip: "Flash system partitions using fastboot"
+        type: "checkbox"
+        value: true
+    prerequisites: []
+    steps:
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://github.com/ubuntu-touch-onclite/ubuntu-touch-onclite/releases/download/20210505/vendor.zip"
+                  name: "vendor.zip"
+                  checksum:
+                    sum: "74aefe78247986fe99ce04ad42f3a6cfe365d66663999ef7d060f90703437ccd"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubuntu-touch-onclite/ubuntu-touch-onclite/releases/download/20210505/dtbo.img"
+                  name: "dtbo.img"
+                  checksum:
+                    sum: "df98bc905a840785c08a3bdeb40d1eddcb07af253c86c9e821d175bed6b6f5d2"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubuntu-touch-onclite/ubuntu-touch-onclite/releases/download/20210505/recovery.img"
+                  name: "recovery.img"
+                  checksum:
+                    sum: "21521603f5381438b496233ada858d933626fc8920548c4dc081df5052d08059"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubuntu-touch-onclite/ubuntu-touch-onclite/releases/download/20210505/vbmeta.img"
+                  name: "vbmeta.img"
+                  checksum:
+                    sum: "c155403e23a18f46c0e7be1164a1b2d47ac3de270b869aac5e5df64fd469927d"
+                    algorithm: "sha256"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "vendor.zip"
+                  dir: "unpacked"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:format:
+              partition: "userdata"
+              type: "ext4"
+        condition:
+          var: "wipe"
+          value: true
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "boot"
+                  file: "recovery.img"
+                  group: "firmware"
+                - partition: "recovery"
+                  file: "recovery.img"
+                  group: "firmware"
+                - partition: "dtbo"
+                  file: "dtbo.img"
+                  group: "firmware"
+                - partition: "vbmeta"
+                  file: "vbmeta.img"
+                  group: "firmware"
+                - partition: "vendor"
+                  file: "unpacked/vendor.img"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:reboot:
+        fallback:
+          - core:user_action:
+              action: "recovery"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - systemimage:install:
+      - actions:
+          - adb:reboot:
+              to_state: "recovery"
+        fallback:
+          - core:user_action:
+              action: "recovery"
+    slideshow: []


### PR DESCRIPTION
Same generation as Redmi Note 7 (lavender) and Redmi Note 7 Pro (violet), but more low end hardware. Based on recently merged `violet` config.

Seems to install fine on mine device.