### PR TITLE
violet: avoid manual unpacking step

### DIFF
--- a/v2/devices/violet.yml
+++ b/v2/devices/violet.yml
@@ -55,18 +55,6 @@ operating_systems:
     prerequisites: []
     steps:
       - actions:
-          - core:manual_download:
-              group: "firmware"
-              file:
-                name: "vendor.img"
-                url: "https://www.androidfilehost.com/?fid=2188818919693784460"
-                checksum:
-                  sum: "a8ca846e06d0e52b812fa0800dcd75991051f7f922d504ebde929bd128085c24"
-                  algorithm: "sha256"
-        condition:
-          var: "bootstrap"
-          value: true
-      - actions:
           - core:download:
               group: "firmware"
               files:
@@ -74,6 +62,40 @@ operating_systems:
                   name: "splash.img"
                 - url: "https://gitlab.com/ubports/community-ports/android9/xiaomi-redmi-note-7-pro/xiaomi-violet/-/jobs/artifacts/master/raw/out/recovery.img?job=devel-flashable"
                   name: "recovery.img"
+                - url: "https://github.com/ubuntu-touch-violet/ubuntu-touch-violet/releases/download/20210510/vendor.zip"
+                  name: "vendor.zip"
+                  checksum:
+                    sum: "e49e199f7980c5200a0b90b489aa0fb6c3d3e612256d6dcac159414f965f0512"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubuntu-touch-violet/ubuntu-touch-violet/releases/download/20210510/dtbo.img"
+                  name: "dtbo.img"
+                  checksum:
+                    sum: "dbeba15ce9345e1a43779b6509fd4dd76eb2c521610eb15203abdcecdb82261b"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubuntu-touch-violet/ubuntu-touch-violet/releases/download/20210510/dsp.img"
+                  name: "dsp.img"
+                  checksum:
+                    sum: "67267993bc3256de9ddb367a8083f66eec2e9036347a1dc2374d8e7e5958462e"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubuntu-touch-violet/ubuntu-touch-violet/releases/download/20210510/bluetooth.img"
+                  name: "bluetooth.img"
+                  checksum:
+                    sum: "b3d78c2c01ea17c78a49ef604cfcde3dc72dcdf7f34c9aa09ce72eded7cbc2f0"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubuntu-touch-violet/ubuntu-touch-violet/releases/download/20210510/modem.img"
+                  name: "modem.img"
+                  checksum:
+                    sum: "e7155f8095a45f1a925bca9c81df145a2e8a90e359a85b5face3986f520ba71c"
+                    algorithm: "sha256"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "vendor.zip"
+                  dir: "unpacked"
         condition:
           var: "bootstrap"
           value: true
@@ -117,8 +139,20 @@ operating_systems:
                 - partition: "splash"
                   file: "splash.img"
                   group: "firmware"
+                - partition: "bluetooth"
+                  file: "bluetooth.img"
+                  group: "firmware"
+                - partition: "dsp"
+                  file: "dsp.img"
+                  group: "firmware"
+                - partition: "dtbo"
+                  file: "dtbo.img"
+                  group: "firmware"
+                - partition: "modem"
+                  file: "modem.img"
+                  group: "firmware"
                 - partition: "vendor"
-                  file: "vendor.img"
+                  file: "unpacked/vendor.img"
                   group: "firmware"
         condition:
           var: "bootstrap"


### PR DESCRIPTION
The installer is able to unpack files, so let's do it for us.
Also, add a few more partitions which might be different depending on
the Android version.