### PR TITLE
beryllium: Add Xiaomi Poco F1

### DIFF
--- a/v2/devices/beryllium.yml
+++ b/v2/devices/beryllium.yml
@@ -1,0 +1,232 @@
+name: "Xiaomi Poco F1"
+codename: "beryllium"
+formfactor: "phone"
+aliases: []
+doppelgangers: []
+user_actions:
+  bootloader:
+    title: "Reboot to Bootloader"
+    description: "With the device powered off, hold Volume Down + Power."
+    image: "phone_power_down"
+    button: true
+  recovery:
+    title: "Reboot to Recovery"
+    description: "With the device powered off, hold Volume Up + Power."
+    image: "phone_power_up"
+    button: true
+  boot:
+    title: "Boot the device"
+    description: "Power on the device."
+    image: "phone_power_up"
+    button: true
+  confirm_model:
+    title: "Confirm your model"
+    description: "Please double-check that your device is a Xiaomi Poco F1 (beryllium)."
+  unlock:
+    title: "OEM unlock"
+    description: "If you haven't done so already, make sure to OEM unlock your device first."
+    link: "https://en.miui.com/unlock/"
+  warning:
+    title: "Warning"
+    description: "The port is based on Android 9 firmware (V11.0.5.0.PEJMIXM) and Lineage 16 vendor image. Current Recovery will be replaced with Ubports Recovery! Remember to flash the latest firmware when reverting to latest Android builds!"
+unlock:
+  - "confirm_model"
+  - "unlock"
+  - "warning"
+handlers:
+  bootloader_locked:
+    actions:
+      - fastboot:oem_unlock:
+operating_systems:
+  - name: "Ubuntu Touch"
+    options:
+      - var: "channel"
+        name: "Channel"
+        tooltip: "The release channel"
+        link: "https://docs.ubports.com/en/latest/about/process/release-schedule.html"
+        type: "select"
+        remote_values:
+          systemimage:channels:
+      - var: "wipe"
+        name: "Wipe Userdata"
+        tooltip: "Wipe personal data"
+        type: "checkbox"
+      - var: "bootstrap"
+        name: "Bootstrap"
+        tooltip: "Flash system partitions using fastboot"
+        type: "checkbox"
+        value: true
+    prerequisites: []
+    steps:
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://cdimage.ubports.com/devices/beryllium/vendor.img"
+                  checksum:
+                    sum: "6c210411fae73a4d44b1fa888b8ae188c97194d9f56eb7aed62ba5d64d6bf39b"
+                    algorithm: "sha256"
+                - url: "https://cdimage.ubports.com/devices/beryllium/recovery.img"
+                  checksum:
+                    sum: "bafe0bcc7a82c6b5d818cc36a400d1de81f7c255767a6b4cf5debe9e2d7d97b5"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubports-beryllium/artifacts/releases/download/stable-v1/firmware.zip"
+                  checksum:
+                    sum: "8b58a71a528ba867dfd2f043da89f6403701fbb524c1a2f0b6ce18b9b4a4cbf2"
+                    algorithm: "sha256"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "firmware.zip"
+                  dir: "unpacked"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:format:
+              partition: "system"
+              type: "ext4"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:format:
+              partition: "cache"
+              type: "ext4"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:format:
+              partition: "userdata"
+              type: "ext4"
+        condition:
+          var: "wipe"
+          value: true
+      - actions:
+          - fastboot:flash:
+              partitions:
+                # Ubports Recovery
+                - partition: "recovery"
+                  file: "recovery.img"
+                  group: "firmware"
+                # Lineage-16 vendor
+                - partition: "vendor"
+                  file: "vendor.img"
+                  group: "firmware"
+                # Firmware files from Android 9 based firmware release: V11.0.5.0.PEJMIXM
+                - partition: "dsp"
+                  file: "unpacked/firmware-update/dsp.img"
+                  group: "firmware"
+                - partition: "cmnlib64_a"
+                  file: "unpacked/firmware-update/cmnlib64.img"
+                  group: "firmware"
+                - partition: "aop_a"
+                  file: "unpacked/firmware-update/aop.img"
+                  group: "firmware"
+                - partition: "devcfg_a"
+                  file: "unpacked/firmware-update/devcfg.img"
+                  group: "firmware"
+                - partition: "qupfw_a"
+                  file: "unpacked/firmware-update/qupfw.img"
+                  group: "firmware"
+                - partition: "tz_a"
+                  file: "unpacked/firmware-update/tz.img"
+                  group: "firmware"
+                - partition: "storsec_a"
+                  file: "unpacked/firmware-update/storsec.img"
+                  group: "firmware"
+                - partition: "keymaster_a"
+                  file: "unpacked/firmware-update/keymaster.img"
+                  group: "firmware"
+                - partition: "bluetooth"
+                  file: "unpacked/firmware-update/bluetooth.img"
+                  group: "firmware"
+                - partition: "xbl_a"
+                  file: "unpacked/firmware-update/xbl.img"
+                  group: "firmware"
+                - partition: "xbl_config_a"
+                  file: "unpacked/firmware-update/xbl_config.img"
+                  group: "firmware"
+                - partition: "abl_a"
+                  file: "unpacked/firmware-update/abl.elf"
+                  group: "firmware"
+                - partition: "logo"
+                  file: "unpacked/firmware-update/logo.img"
+                  group: "firmware"
+                - partition: "cmnlib_a"
+                  file: "unpacked/firmware-update/cmnlib.img"
+                  group: "firmware"
+                - partition: "hyp_a"
+                  file: "unpacked/firmware-update/hyp.img"
+                  group: "firmware"
+                - partition: "cmnlib64_b"
+                  file: "unpacked/firmware-update/cmnlib64.img"
+                  group: "firmware"
+                - partition: "aop_b"
+                  file: "unpacked/firmware-update/aop.img"
+                  group: "firmware"
+                - partition: "devcfg_b"
+                  file: "unpacked/firmware-update/devcfg.img"
+                  group: "firmware"
+                - partition: "qupfw_b"
+                  file: "unpacked/firmware-update/qupfw.img"
+                  group: "firmware"
+                - partition: "tz_b"
+                  file: "unpacked/firmware-update/tz.img"
+                  group: "firmware"
+                - partition: "storsec_b"
+                  file: "unpacked/firmware-update/storsec.img"
+                  group: "firmware"
+                - partition: "keymaster_b"
+                  file: "unpacked/firmware-update/keymaster.img"
+                  group: "firmware"
+                - partition: "xbl_b"
+                  file: "unpacked/firmware-update/xbl.img"
+                  group: "firmware"
+                - partition: "xbl_config_b"
+                  file: "unpacked/firmware-update/xbl_config.img"
+                  group: "firmware"
+                - partition: "abl_b"
+                  file: "unpacked/firmware-update/abl.elf"
+                  group: "firmware"
+                - partition: "cmnlib_b"
+                  file: "unpacked/firmware-update/cmnlib.img"
+                  group: "firmware"
+                - partition: "hyp_b"
+                  file: "unpacked/firmware-update/hyp.img"
+                  group: "firmware"
+                - partition: "modem"
+                  file: "unpacked/firmware-update/modem.img"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - core:user_action:
+              action: "recovery"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - systemimage:install:
+      - actions:
+          - adb:reboot:
+              to_state: "recovery"
+        fallback:
+          - core:user_action:
+              action: "recovery"
+    slideshow: []


### PR DESCRIPTION
I m using `ubports-installer-support.zip` to hold the firmware, vendor and ubports recovery image. This makes manual download a bit easier for the user, as they are not needed to enter the path for each file. 

For reference:
1. Firmware - V11.0.5.0.PEJMIXM (Android 9 based firmware is needed for Poco F1, but most of the devices are updated to android 10 which doesnt work)
2. vendor.img - Lineage 16.0 vendor partition
3. recovery.img - Ubports Recovery