### PR TITLE
perseus: add Xiaomi Mi MIX 3

### DIFF
--- a/v2/devices/perseus.yml
+++ b/v2/devices/perseus.yml
@@ -1,0 +1,138 @@
+name: "Xiaomi Mi MIX 3"
+codename: "perseus"
+formfactor: "phone"
+aliases: []
+doppelgangers: []
+user_actions:
+  recovery:
+    title: "Reboot to Recovery"
+    description: "With the device powered off, hold Volume Up + Power."
+    image: "phone_power_up"
+    button: true
+  bootloader:
+    title: "Reboot to Bootloader"
+    description: "With the device powered off, hold Volume Down + Power."
+    image: "phone_power_down"
+    button: true
+  boot:
+    title: "Boot the device"
+    description: "Power on the device."
+    image: "phone_power_up"
+    button: true
+  confirm_model:
+    title: "Confirm your model"
+    description: "Please double-check that your device is a Xiaomi Mi MIX 3 (perseus)."
+  unlock:
+    title: "OEM unlock"
+    description: "If you haven't done so already, make sure to OEM unlock your device first."
+    link: "https://en.miui.com/unlock/"
+unlock:
+  - "confirm_model"
+  - "unlock"
+handlers:
+  bootloader_locked:
+    actions:
+      - fastboot:oem_unlock:
+operating_systems:
+  - name: "Ubuntu Touch"
+    options:
+      - var: "channel"
+        name: "Channel"
+        tooltip: "The release channel"
+        link: "https://docs.ubports.com/en/latest/about/process/release-schedule.html"
+        type: "select"
+        remote_values:
+          systemimage:channels:
+      - var: "wipe"
+        name: "Wipe Userdata"
+        tooltip: "Wipe personal data (required if the previously installed OS is Android, MIUI or LineageOS)"
+        type: "checkbox"
+      - var: "bootstrap"
+        name: "Bootstrap"
+        tooltip: "Flash system partitions using fastboot"
+        type: "checkbox"
+        value: true
+    prerequisites: []
+    steps:
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://github.com/ubports-perseus/ubuntu-touch-perseus/releases/download/v1.0-beta/vendor.zip"
+                  name: "vendor.zip"
+                  checksum:
+                    sum: "421654f9b51d68c240d71cb9d3ae9b7dc1c53521d6a768c92625255dc943c189"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubports-perseus/ubuntu-touch-perseus/releases/download/v1.0-beta/dtbo.img"
+                  name: "dtbo.img"
+                  checksum:
+                    sum: "d047c49bf4073b09174ee92b07133de865285de973b47910699f2b227ac10dd0"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubports-perseus/ubuntu-touch-perseus/releases/download/v1.0-beta/recovery.img"
+                  name: "recovery.img"
+                  checksum:
+                    sum: "93396a51bfe47b2fd5d2bfcbcfa0aab78e43c62e63e5f473942613483b6b0c59"
+                    algorithm: "sha256"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "vendor.zip"
+                  dir: "unpacked"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:format:
+              partition: "userdata"
+              type: "ext4"
+        condition:
+          var: "wipe"
+          value: true
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "boot"
+                  file: "recovery.img"
+                  group: "firmware"
+                - partition: "recovery"
+                  file: "recovery.img"
+                  group: "firmware"
+                - partition: "dtbo"
+                  file: "dtbo.img"
+                  group: "firmware"
+                - partition: "vendor"
+                  file: "unpacked/vendor.img"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:reboot:
+        fallback:
+          - core:user_action:
+              action: "recovery"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - systemimage:install:
+      - actions:
+          - adb:reboot:
+              to_state: "recovery"
+        fallback:
+          - core:user_action:
+              action: "recovery"
+    slideshow: []


### PR DESCRIPTION
Adding installer configs for Xiaomi Mi MIX 3 (perseus), tested and confirm successful installation via `ubports-installer --file perseus.yml`.

Since most of users are on Android 10, Android 9 vendor is needed to boot. I included stock Android 9 vendor as part of the installer (source: [V9.9.3](https://xiaomifirmwareupdater.com/miui/perseus/weekly/9.9.3/)).

The dtbo.img is also required to boot, the one from stock doesn’t work. It was built locally from halium 9 porting. 


