### PR TITLE
miatoll: add Xiaomi Redmi Note 9 Pro/Pro Max/9S - Poco M2 Pro

### DIFF
--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -1,0 +1,140 @@
+name: "Xiaomi Redmi Note 9 Pro/Pro Max/9S - Poco M2 Pro"
+codename: "miatoll"
+aliases:
+  - "joyeuse"
+  - "curtana"
+  - "excalibur"
+  - "gram"
+formfactor: "phone"
+doppelgangers: []
+user_actions:
+  recovery:
+    title: "Reboot to Recovery"
+    description: "With the device powered off, hold Volume Up + Power."
+    image: "phone_power_up"
+    button: true
+  bootloader:
+    title: "Reboot to Bootloader"
+    description: "With the device powered off, hold Volume Down + Power."
+    image: "phone_power_down"
+    button: true
+  boot:
+    title: "Boot the device"
+    description: "Power on the device."
+    image: "phone_power_up"
+    button: true
+  confirm_model:
+    title: "Confirm your model"
+    description: "Please double-check that your device is any of the following models: Xiaomi Redmi Note 9 Pro/Pro Max/9S - Poco M2 Pro (joyeuse, excalibur, curtana, gram)."
+  confirm_firmware:
+    title: "Confirm your firmware"
+    description: "Please double-check that your device is running the latest available stock Android 10 firmware."
+    link: "https://github.com/ubuntu-touch-miatoll/ubuntu-touch-miatoll/blob/main/FIRMWARE.md"
+  unlock:
+    title: "OEM unlock"
+    description: "If you haven't done so already, make sure to OEM unlock your device first."
+    link: "https://en.miui.com/unlock/"
+unlock:
+  - "confirm_model"
+  - "confirm_firmware"
+  - "unlock"
+handlers:
+  bootloader_locked:
+    actions:
+      - fastboot:oem_unlock:
+operating_systems:
+  - name: "Ubuntu Touch"
+    options:
+      - var: "channel"
+        name: "Channel"
+        tooltip: "The release channel"
+        link: "https://docs.ubports.com/en/latest/about/process/release-schedule.html"
+        type: "select"
+        remote_values:
+          systemimage:channels:
+      - var: "wipe"
+        name: "Wipe Userdata"
+        tooltip: "Wipe personal data"
+        type: "checkbox"
+      - var: "bootstrap"
+        name: "Bootstrap"
+        tooltip: "Flash system partitions using fastboot"
+        type: "checkbox"
+        value: true
+    prerequisites: []
+    steps:
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://github.com/ubuntu-touch-miatoll/ubuntu-touch-miatoll/releases/download/20211021/recovery.img"
+                  name: "recovery.img"
+                  checksum:
+                    sum: "116d7ca8a0b241665cc1b52653242f3385d28c4dcac4eafe0ba6d437570a1d48"
+                    algorithm: "sha256"
+                - url: "https://github.com/ubuntu-touch-miatoll/ubuntu-touch-miatoll/releases/download/20211021/dtbo.img"
+                  name: "dtbo.img"
+                  checksum:
+                    sum: "a65c5a092604eb9b7e9d92c4504c3ae8bbde33d76060923be488bc031bacff79"
+                    algorithm: "sha256"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:format:
+              partition: "cache"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:format:
+              partition: "userdata"
+              type: "ext4"
+        condition:
+          var: "wipe"
+          value: true
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "recovery"
+                  file: "recovery.img"
+                  group: "firmware"
+                - partition: "dtbo"
+                  file: "dtbo.img"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+        - fastboot:reboot_bootloader:
+        fallback:
+          - core:user_action:
+              action: "recovery"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:boot:
+              file: "recovery.img"
+              group: "firmware"
+        fallback:
+          - core:user_action:
+              action: "recovery"
+      - actions:
+          - systemimage:install:
+      - actions:
+          - adb:reboot:
+              to_state: "recovery"
+        fallback:
+          - core:user_action:
+              action: "recovery"
+    slideshow: []


### PR DESCRIPTION
Tested multiple times, breaks only if the installer already succeeded thus I avoided flashing  `recovery.img` to the boot partition so it won't break the booting process. 