### PR TITLE
devices: Improve "Wipe Userdata" warning

### DIFF
--- a/v2/devices/FP2.yml
+++ b/v2/devices/FP2.yml
@@ -32,7 +32,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/FP2.yml
+++ b/v2/devices/FP2.yml
@@ -32,7 +32,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/angler.yml
+++ b/v2/devices/angler.yml
@@ -46,7 +46,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/angler.yml
+++ b/v2/devices/angler.yml
@@ -46,7 +46,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/arale.yml
+++ b/v2/devices/arale.yml
@@ -37,7 +37,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/arale.yml
+++ b/v2/devices/arale.yml
@@ -37,7 +37,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/bacon.yml
+++ b/v2/devices/bacon.yml
@@ -33,7 +33,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/bacon.yml
+++ b/v2/devices/bacon.yml
@@ -33,7 +33,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/beryllium.yml
+++ b/v2/devices/beryllium.yml
@@ -49,7 +49,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/beryllium.yml
+++ b/v2/devices/beryllium.yml
@@ -49,7 +49,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/cheeseburger.yml
+++ b/v2/devices/cheeseburger.yml
@@ -67,7 +67,7 @@ operating_systems:
         type: "checkbox"
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
     prerequisites: []
     steps:

--- a/v2/devices/cheeseburger.yml
+++ b/v2/devices/cheeseburger.yml
@@ -67,7 +67,7 @@ operating_systems:
         type: "checkbox"
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
     prerequisites: []
     steps:

--- a/v2/devices/citrus.yml
+++ b/v2/devices/citrus.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/citrus.yml
+++ b/v2/devices/citrus.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/cooler.yml
+++ b/v2/devices/cooler.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/cooler.yml
+++ b/v2/devices/cooler.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/deb.yml
+++ b/v2/devices/deb.yml
@@ -35,7 +35,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/deb.yml
+++ b/v2/devices/deb.yml
@@ -35,7 +35,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/dipper.yml
+++ b/v2/devices/dipper.yml
@@ -49,7 +49,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/dipper.yml
+++ b/v2/devices/dipper.yml
@@ -49,7 +49,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/dora.yml
+++ b/v2/devices/dora.yml
@@ -57,7 +57,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/dora.yml
+++ b/v2/devices/dora.yml
@@ -57,7 +57,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/dumpling.yml
+++ b/v2/devices/dumpling.yml
@@ -67,7 +67,7 @@ operating_systems:
         type: "checkbox"
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
     prerequisites: []
     steps:

--- a/v2/devices/dumpling.yml
+++ b/v2/devices/dumpling.yml
@@ -67,7 +67,7 @@ operating_systems:
         type: "checkbox"
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
     prerequisites: []
     steps:

--- a/v2/devices/enchilada.yml
+++ b/v2/devices/enchilada.yml
@@ -43,7 +43,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/enchilada.yml
+++ b/v2/devices/enchilada.yml
@@ -43,7 +43,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/flo.yml
+++ b/v2/devices/flo.yml
@@ -35,7 +35,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/flo.yml
+++ b/v2/devices/flo.yml
@@ -35,7 +35,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/frieza.yml
+++ b/v2/devices/frieza.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/frieza.yml
+++ b/v2/devices/frieza.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/hammerhead.yml
+++ b/v2/devices/hammerhead.yml
@@ -36,7 +36,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/hammerhead.yml
+++ b/v2/devices/hammerhead.yml
@@ -36,7 +36,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/jasmine_sprout.yml
+++ b/v2/devices/jasmine_sprout.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/jasmine_sprout.yml
+++ b/v2/devices/jasmine_sprout.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/kagura.yml
+++ b/v2/devices/kagura.yml
@@ -56,7 +56,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/kagura.yml
+++ b/v2/devices/kagura.yml
@@ -56,7 +56,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/karin.yml
+++ b/v2/devices/karin.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/karin.yml
+++ b/v2/devices/karin.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/krillin.yml
+++ b/v2/devices/krillin.yml
@@ -37,7 +37,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/krillin.yml
+++ b/v2/devices/krillin.yml
@@ -37,7 +37,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/kugo.yml
+++ b/v2/devices/kugo.yml
@@ -46,7 +46,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/kugo.yml
+++ b/v2/devices/kugo.yml
@@ -46,7 +46,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/lancelot.yml
+++ b/v2/devices/lancelot.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/lancelot.yml
+++ b/v2/devices/lancelot.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/lavender.yml
+++ b/v2/devices/lavender.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/lavender.yml
+++ b/v2/devices/lavender.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/mako.yml
+++ b/v2/devices/mako.yml
@@ -29,7 +29,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/mako.yml
+++ b/v2/devices/mako.yml
@@ -29,7 +29,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/merlin.yml
+++ b/v2/devices/merlin.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/merlin.yml
+++ b/v2/devices/merlin.yml
@@ -45,7 +45,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -54,7 +54,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -54,7 +54,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/oneplus2.yml
+++ b/v2/devices/oneplus2.yml
@@ -63,7 +63,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "logo"
         name: "Flash Logo"

--- a/v2/devices/oneplus2.yml
+++ b/v2/devices/oneplus2.yml
@@ -63,7 +63,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "logo"
         name: "Flash Logo"

--- a/v2/devices/oneplus3.yml
+++ b/v2/devices/oneplus3.yml
@@ -68,7 +68,7 @@ operating_systems:
         type: "checkbox"
       - var: "wipe"
         name: "Factory Reset"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
     prerequisites: []
     steps:

--- a/v2/devices/oneplus3.yml
+++ b/v2/devices/oneplus3.yml
@@ -68,7 +68,7 @@ operating_systems:
         type: "checkbox"
       - var: "wipe"
         name: "Factory Reset"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
     prerequisites: []
     steps:

--- a/v2/devices/pro1.yml
+++ b/v2/devices/pro1.yml
@@ -31,7 +31,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/pro1.yml
+++ b/v2/devices/pro1.yml
@@ -31,7 +31,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/s3ve3g.yml
+++ b/v2/devices/s3ve3g.yml
@@ -43,7 +43,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/s3ve3g.yml
+++ b/v2/devices/s3ve3g.yml
@@ -43,7 +43,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/sargo.yml
+++ b/v2/devices/sargo.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/sargo.yml
+++ b/v2/devices/sargo.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/suzu.yml
+++ b/v2/devices/suzu.yml
@@ -57,7 +57,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/suzu.yml
+++ b/v2/devices/suzu.yml
@@ -57,7 +57,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/taimen.yml
+++ b/v2/devices/taimen.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/taimen.yml
+++ b/v2/devices/taimen.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/trlte.yml
+++ b/v2/devices/trlte.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
     prerequisites:
       - "trlte_check"

--- a/v2/devices/trlte.yml
+++ b/v2/devices/trlte.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
     prerequisites:
       - "trlte_check"

--- a/v2/devices/trltespr.yml
+++ b/v2/devices/trltespr.yml
@@ -42,7 +42,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
     prerequisites:
       - "trlte_check"

--- a/v2/devices/trltespr.yml
+++ b/v2/devices/trltespr.yml
@@ -42,7 +42,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
     prerequisites:
       - "trlte_check"

--- a/v2/devices/trltetmo.yml
+++ b/v2/devices/trltetmo.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
     prerequisites:
       - "trlte_check"

--- a/v2/devices/trltetmo.yml
+++ b/v2/devices/trltetmo.yml
@@ -41,7 +41,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
     prerequisites:
       - "trlte_check"

--- a/v2/devices/turbo.yml
+++ b/v2/devices/turbo.yml
@@ -38,7 +38,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/turbo.yml
+++ b/v2/devices/turbo.yml
@@ -38,7 +38,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/vegetahd.yml
+++ b/v2/devices/vegetahd.yml
@@ -37,7 +37,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/vegetahd.yml
+++ b/v2/devices/vegetahd.yml
@@ -37,7 +37,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/yggdrasil.yml
+++ b/v2/devices/yggdrasil.yml
@@ -61,7 +61,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data"
+        tooltip: "Wipe personal data (recommended for first time installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"

--- a/v2/devices/yggdrasil.yml
+++ b/v2/devices/yggdrasil.yml
@@ -61,7 +61,7 @@ operating_systems:
           systemimage:channels:
       - var: "wipe"
         name: "Wipe Userdata"
-        tooltip: "Wipe personal data (recommended for first time installs)"
+        tooltip: "Wipe personal data (required for new installs)"
         type: "checkbox"
       - var: "bootstrap"
         name: "Bootstrap"


### PR DESCRIPTION
Whole categories of issues can be fixed by instructing the user to
wipe userdata at the time of first installing Ubuntu Touch.
Add a warning to those devices that don't already have extended
information about requring userdata wipe.

I would personally prefer to keep the wipe option off by default,
especially for those users who would not like if their userdata
was reset back to a factory state when all they wanted was to
reflash a broken installation.