### PR TITLE
Also mention the Fairphone 3+ in the device name

### DIFF
--- a/v2/devices/FP3.yml
+++ b/v2/devices/FP3.yml
@@ -9,7 +9,7 @@ user_actions:
     description: "Please check that your device is a Fairphone 3 (FP3) or Fairphone 3+ (FP3+)."
   confirm_os:
     title: "Confirm OS version"
-    description: "Your device must be running Android 10 before installing Ubuntu Touch. If it is already running the previous Halium 9 version of Ubuntu Touch and you want to upgrade to the Halium 10 (recommended), you can download and flash the Android 10 stock rom from the link below (More...), which leaves your userdata partition untouched. Afterwards run this installer again."
+    description: "Your device must be running the Fairphone OS version of Android 10 before installing Ubuntu Touch. With a previously installed /e/ OS, it won't work! Only if it is already running the previous Halium 9 version of Ubuntu Touch and you want to upgrade to the Halium 10 (recommended), you can download and flash the Android 10 stock rom from the link below (More...), which leaves your userdata partition untouched. Afterwards run this installer again."
     link: "https://androidfilehost.com/?fid=7161016148664787652"
   unlock_bootloader:
     title: "Unlock your phone"


### PR DESCRIPTION
Sorry, I forgot to add the 3**+** to the device name, which makes it clearer to owners of the Fairphone 3+, that this installer is also working for them.