### PR TITLE
devices: add support for SHIFT SHIFT6mq (axolotl)

### DIFF
--- a/v2/devices/axolotl.yml
+++ b/v2/devices/axolotl.yml
@@ -1,0 +1,220 @@
+name: "SHIFT SHIFT6mq"
+codename: "axolotl"
+formfactor: "phone"
+aliases: []
+doppelgangers: []
+user_actions:
+  confirm_installer:
+    title: "Confirm UBports installer version"
+    description: "Please check that the version of the UBports installer is at least 0.9.2-beta."
+  confirm_model:
+    title: "Confirm your model"
+    description: "Please check that your device is a SHIFT6mq (axolotl)."
+  confirm_os:
+    title: "Confirm OS version"
+    description: "Please double-check that your device is running the latest available stock Android 10 firmware (type: release)."
+    link: "https://downloads.shiftphones.com/axolotl"
+  unlock_bootloader:
+    title: "Unlock your phone"
+    description: 'Your device must be "unlocked" in order to be able to flash it. Unlocking the bootloader will delete your personal data!<br><br>If your bootloader is already unlocked, you are good to go. Otherwise please check the link below (More...) and follow the instructions.'
+    link: "https://wiki.lineageos.org/devices/axolotl/install#unlocking-the-bootloader"
+  bootloader:
+    title: "Reboot to Bootloader"
+    description: "With the device powered off, hold Volume Up + Power."
+    image: "phone_power_up"
+    button: true
+  recovery:
+    title: "Reboot to Recovery"
+    description: "With the device powered off, hold Volume Down + Power."
+    image: "phone_power_down"
+    button: true
+unlock:
+  - "confirm_installer"
+  - "confirm_model"
+  - "confirm_os"
+  - "unlock_bootloader"
+handlers:
+  bootloader_locked:
+    actions:
+      - fastboot:flashing_unlock:
+operating_systems:
+  - name: "Ubuntu Touch"
+    options:
+      - var: "channel"
+        name: "Channel"
+        tooltip: "The release channel"
+        link: "https://docs.ubports.com/en/latest/about/process/release-schedule.html"
+        type: "select"
+        remote_values:
+          systemimage:channels:
+      - var: "wipe"
+        name: "Wipe personal data"
+        tooltip: "This is required for new installations"
+        type: "checkbox"
+        value: true
+      - var: "bootstrap"
+        name: "Bootstrap"
+        tooltip: "Setup required partitions for running Ubuntu Touch"
+        type: "checkbox"
+        value: true
+    prerequisites: []
+    steps:
+      ######################################################################
+      ###
+      ### Ensure we always start in bootloader mode
+      ###
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+      ### As this is an A/B device, force all future operations in "a" slot.
+      - actions:
+          - fastboot:set_active:
+              slot: "a"
+      ###
+      ######################################################################
+
+      ######################################################################
+      ###
+      ### (Optional) Wipe steps
+      ###
+      # 1) Format userdata as f2fs
+      - actions:
+          - fastboot:format:
+              partition: "userdata"
+              type: "f2fs"
+        condition:
+          var: "wipe"
+          value: true
+      # 2) Format metadata as ext4
+      - actions:
+          - fastboot:format:
+              partition: "metadata"
+              type: "ext4"
+        condition:
+          var: "wipe"
+          value: true
+      # 3) Erase misc
+      - actions:
+          - fastboot:erase:
+              partition: "misc"
+        condition:
+          var: "wipe"
+          value: true
+      ###
+      ######################################################################
+
+      ######################################################################
+      ###
+      ### (Optional) Bootstrap steps
+      ###
+      # 1) Download firmware images
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://gitlab.com/SHIFTPHONES/ubports/assets/-/raw/06fa047c3afcceb0532f90e8b503ff6a963bec56/axolotl/images/dtbo.img"
+                  name: "dtbo.img"
+                  checksum:
+                    sum: "471a08f3bfaeb13f25e54b5e3aa84f573955da8578326564a6d2fe1c1d739512"
+                    algorithm: "sha256"
+                - url: "https://gitlab.com/SHIFTPHONES/ubports/assets/-/raw/06fa047c3afcceb0532f90e8b503ff6a963bec56/axolotl/images/recovery.img"
+                  name: "recovery.img"
+                  checksum:
+                    sum: "a4a42acb7a2fe4f608c46c7cfe7114f634e6d0c0e9402874de92e6a27ce7b3c3"
+                    algorithm: "sha256"
+                - url: "https://gitlab.com/SHIFTPHONES/ubports/assets/-/raw/06fa047c3afcceb0532f90e8b503ff6a963bec56/axolotl/images/super_mainline.img"
+                  name: "super_mainline.img"
+                  checksum:
+                    sum: "759c3bff7358ade708ba515ffb4200883cbca5f64020c26fd9b049bb68f13dcc"
+                    algorithm: "sha256"
+                - url: "https://gitlab.com/SHIFTPHONES/ubports/assets/-/raw/06fa047c3afcceb0532f90e8b503ff6a963bec56/axolotl/images/vbmeta.img"
+                  name: "vbmeta.img"
+                  checksum:
+                    sum: "e609f4ec50b4748d078474075ecb52b2fc44a1e90b70de483f8fa1e4865f0f0a"
+                    algorithm: "sha256"
+                - url: "https://gitlab.com/SHIFTPHONES/ubports/assets/-/raw/06fa047c3afcceb0532f90e8b503ff6a963bec56/axolotl/images/vendor.img"
+                  name: "vendor.img"
+                  checksum:
+                    sum: "38c237ca8f62c422edcbe84c73355d9847bd1deb167022c6301130c5252d5e9f"
+                    algorithm: "sha256"
+        condition:
+          var: "bootstrap"
+          value: true
+      # 2) Flash firmware images in bootloader fastboot mode
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "dtbo"
+                  file: "dtbo.img"
+                  group: "firmware"
+                - partition: "recovery"
+                  file: "recovery.img"
+                  group: "firmware"
+                - partition: "vbmeta"
+                  file: "vbmeta.img"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+      # 3) Flash firmware images in fastbootd mode
+      - actions:
+          - fastboot:reboot_fastboot:
+        condition:
+          var: "bootstrap"
+          value: true
+        # TODO: implement user action fallback for fastbootd
+        #fallback:
+        #  - core:user_action:
+        #      action: "fastbootd"
+      - actions:
+          - fastboot:wipe_super:
+              image:
+                file: "super_mainline.img"
+                group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "vendor"
+                  file: "vendor.img"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+      # 4) Reboot back into bootloader mode
+      - actions:
+          - fastboot:reboot_bootloader:
+        condition:
+          var: "bootstrap"
+          value: true
+      ###
+      ######################################################################
+
+      ######################################################################
+      ###
+      ### Systemimage installation steps
+      ###
+      # 1) Reboot to recovery
+      - actions:
+          - fastboot:reboot_recovery:
+        fallback:
+          - core:user_action:
+              action: "recovery"
+      # 2) Start systemimage installation
+      - actions:
+          - systemimage:install:
+      # 3) Reboot to recovery to trigger installation
+      - actions:
+          - adb:reboot:
+              to_state: "recovery"
+        fallback:
+          - core:user_action:
+              action: "recovery"
+      ###
+      ######################################################################
+    slideshow: []


### PR DESCRIPTION
This adds the config file for SHIFT6mq (axolotl) and also adds `f2fs` as supported partition type (which is used by axolotl).