### PR TITLE
FP3: Fix pushing data to phone, when userdata is encrypted

### DIFF
--- a/v2/devices/FP3.yml
+++ b/v2/devices/FP3.yml
@@ -85,6 +85,12 @@ operating_systems:
           var: "bootstrap"
           value: true
       - actions:
+          - fastboot:erase:
+              partition: "userdata"
+        condition:
+          var: "wipe"
+          value: true
+      - actions:
           - fastboot:format:
               partition: "userdata"
               type: "ext4"


### PR DESCRIPTION
Fixes Error: {"error":{"code":1,"cmd":"adb -P 5037 shell mkdir -p /cache/recovery"},"stderr":"mkdir: '/cache/recovery': Required key not available"}

^^ Appears on first installs, coming from Android OS'.