### PR TITLE
Unpacking Volla OS zip fails due to wrong archive name.

### DIFF
--- a/v2/devices/yggdrasil.yml
+++ b/v2/devices/yggdrasil.yml
@@ -209,7 +209,7 @@ operating_systems:
           - core:unpack:
               group: "firmware"
               files:
-                - archive: "vollaos-10.0-ubports.zip"
+                - archive: "vollaos-10.0-16-nov-2021-ubports.zip"
                   dir: "unpacked"
       - actions:
           - adb:reboot:


### PR DESCRIPTION
Hi There,

I just tried to flash Volla OS to a Volla Phone but I got an error during unpacking.
This seems to be related to the archive name, which is different from the downloaded file name.
After updating the archive name in the yml file, the procedure worked as expacted.
The archive name is fixed with this pull request.

best regards,
Daniel