### PR TITLE
Pixel 2: Update boot.img checksums

### DIFF
--- a/v2/devices/taimen.yml
+++ b/v2/devices/taimen.yml
@@ -56,7 +56,7 @@ operating_systems:
               files:
                 - url: "https://cdimage.ubports.com/devices/taimen/boot.img"
                   checksum:
-                    sum: "f03afb829cbc2b5538ece9087d1cb8770addff0347f98eac82b8f0893df06101"
+                    sum: "3b81339938fc541ff07f0b6562af1865d599a83a662f896cd0bb8ca237c26bb9"
                     algorithm: "sha256"
                 - url: "https://cdimage.ubports.com/devices/taimen/dtbo.img"
                   checksum:

--- a/v2/devices/walleye.yml
+++ b/v2/devices/walleye.yml
@@ -56,7 +56,7 @@ operating_systems:
               files:
                 - url: "https://cdimage.ubports.com/devices/walleye/boot.img"
                   checksum:
-                    sum: "ae3cefe83a05dfa8aa619fab9636c29fd13b23bb4415adab5f2669466b3e9617"
+                    sum: "b3c54817559580217a137e897174f5c0c59d4b1a682d4e1d12b170d290df6f01"
                     algorithm: "sha256"
                 - url: "https://cdimage.ubports.com/devices/walleye/dtbo.img"
                   checksum:


### PR DESCRIPTION
Due to https://github.com/ubports/ubuntu-touch/issues/1916 we had to update boot images