### PR TITLE
devices: Added support for Xiaomi Mi A3 (laurel_sprout)

### DIFF
--- a/v2/devices/laurel_sprout.yml
+++ b/v2/devices/laurel_sprout.yml
@@ -61,15 +61,15 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://gitlab.com/ubports/community-ports/android9/xiaomi-mi-a3/xiaomi-laurel_sprout/-/jobs/2005822461/artifacts/raw/out/boot.img"
+                - url: "https://fs.nightcore.monster/ubports/laurel_sprout/boot.img"
                   checksum:
                     sum: "89876301997f4299d27be397a9544d1b2dc5afd145cbba866b83ebb8b1c14816"
                     algorithm: "sha256"
-                - url: "https://gitlab.com/nixeko/halium-ports/laurel_sprout/lunecrash/-/jobs/2004894571/artifacts/raw/output/arch/arm64/boot/dtbo.img"
+                - url: "https://fs.nightcore.monster/ubports/laurel_sprout/dtbo.img"
                   checksum:
                     sum: "a0266fba49eb2d3ed035a1e0fc87759eba1ad9ffd247e35e50229f45d3698629"
                     algorithm: "sha256"
-                - url: "https://cdimage.ubports.com/devices/lavender/vbmeta.img"
+                - url: "https://fs.nightcore.monster/ubports/laurel_sprout/vbmeta.img"
                   checksum:
                     sum: "65f5493e01ede7e538a14df063013a921ecd122680c7d3b3598d46fc7a916517"
                     algorithm: "sha256"
@@ -154,7 +154,7 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://gitlab.com/nixeko/halium-ports/laurel_sprout/lunecrash/-/jobs/2004894571/artifacts/raw/output/arch/arm64/boot/dtbo.img"
+                - url: "https://fs.nightcore.monster/ubports/laurel_sprout/dtbo.img"
                   checksum:
                     sum: "a0266fba49eb2d3ed035a1e0fc87759eba1ad9ffd247e35e50229f45d3698629"
                     algorithm: "sha256"

--- a/v2/devices/laurel_sprout.yml
+++ b/v2/devices/laurel_sprout.yml
@@ -1,0 +1,178 @@
+name: "Xiaomi Mi A3"
+codename: "laurel_sprout"
+formfactor: "phone"
+aliases: []
+doppelgangers: []
+user_actions:
+  confirm_model:
+    title: "Confirm your model"
+    description: "Please double-check that your device is a Xiaomi Mi A3 (laurel_sprout). Xiaomi Mi CC9e is NOT supported."
+  confirm_os:
+    title: "Confirm OS version"
+    description: "Your device must be running the stock Android 9 firmware before flashing. If your device is running Android 11 officially, DO NOT ATTEMPT TO ROLLBACK TO ANDROID 9. Doing so will render your device unusable. If your device is running Android 10, download the Android 9 firmware linked below and flash it to your device, then resume the installation."
+    link: "http://bigota.d.miui.com/V10.3.16.0.PFQMIXM/laurel_sprout_global_images_V10.3.16.0.PFQMIXM_20200324.0000.00_9.0_4a60d662bd.tgz"
+  troubleshooting:
+    title: "Post-Install troubleshooting"
+    description: "If after installing Ubuntu Touch you can't connect to Wi-Fi, pair Bluetooth devices or use cellular data, run the installer again and pick \"Reflash dtbo\" when you're prompted to select an OS."
+  bootloader:
+    title: "Reboot to Bootloader"
+    description: "With the device powered off, press and hold the VOLUME DOWN and POWER buttons until the screen turns on"
+    image: "phone_power_down"
+    button: true
+  recovery:
+    title: "Reboot to Recovery"
+    description: "With the device still at the 'Fastboot' screen, press and hold VOLUME UP and POWER buttons until the screen turns on"
+    image: "phone_power_up"
+    button: true
+  boot:
+    title: "Reboot the device"
+    description: "Hold down the power button until the device powers down. Then, release it briefly and hold it down again until the device boots."
+    button: true
+unlock:
+  - "confirm_model"
+  - "confirm_os"
+  - "troubleshooting"
+handlers:
+  bootloader_locked:
+    actions:
+      - fastboot:flashing_unlock:
+operating_systems:
+  - name: "Ubuntu Touch"
+    options:
+      - var: "channel"
+        name: "Channel"
+        tooltip: "The release channel"
+        link: "https://docs.ubports.com/en/latest/about/process/release-schedule.html"
+        type: "select"
+        remote_values:
+          systemimage:channels:
+      - var: "wipe"
+        name: "Wipe Userdata"
+        tooltip: "Wipe personal data"
+        type: "checkbox"
+      - var: "bootstrap"
+        name: "Bootstrap"
+        tooltip: "Flash system partitions using fastboot"
+        type: "checkbox"
+        value: true
+    prerequisites: []
+    steps:
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://gitlab.com/ubports/community-ports/android9/xiaomi-mi-a3/xiaomi-laurel_sprout/-/jobs/2005822461/artifacts/raw/out/boot.img"
+                  checksum:
+                    sum: "89876301997f4299d27be397a9544d1b2dc5afd145cbba866b83ebb8b1c14816"
+                    algorithm: "sha256"
+                - url: "https://gitlab.com/nixeko/halium-ports/laurel_sprout/lunecrash/-/jobs/2004894571/artifacts/raw/output/arch/arm64/boot/dtbo.img"
+                  checksum:
+                    sum: "a0266fba49eb2d3ed035a1e0fc87759eba1ad9ffd247e35e50229f45d3698629"
+                    algorithm: "sha256"
+                - url: "https://cdimage.ubports.com/devices/lavender/vbmeta.img"
+                  checksum:
+                    sum: "65f5493e01ede7e538a14df063013a921ecd122680c7d3b3598d46fc7a916517"
+                    algorithm: "sha256"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:set_active:
+              slot: "a"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:format:
+              partition: "system"
+              type: "ext4"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:format:
+              partition: "userdata"
+              type: "ext4"
+        condition:
+          var: "wipe"
+          value: true
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "vbmeta_a"
+                  file: "vbmeta.img"
+                  group: "firmware"
+                - partition: "boot_a"
+                  file: "boot.img"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - adb:reboot:
+              to_state: "recovery"
+        fallback:
+          - core:user_action:
+              action: "recovery"
+      - actions:
+          - systemimage:install:
+      - actions:
+          - core:user_action:
+              action: "bootloader"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "dtbo_a"
+                  file: "dtbo.img"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - adb:reboot:
+              to_state: "recovery"
+        fallback:
+          - core:user_action:
+              action: "recovery"
+    slideshow: []
+  - name: "Reflash dtbo"
+    prerequisites: []
+    steps:
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://gitlab.com/nixeko/halium-ports/laurel_sprout/lunecrash/-/jobs/2004894571/artifacts/raw/output/arch/arm64/boot/dtbo.img"
+                  checksum:
+                    sum: "a0266fba49eb2d3ed035a1e0fc87759eba1ad9ffd247e35e50229f45d3698629"
+                    algorithm: "sha256"
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+              - core:user_action:
+                  action: "bootloader"
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "dtbo"
+                  file: "dtbo.img"
+                  group: "firmware"
+      - actions:
+          - fastboot:reboot:
+        fallback:
+          - core:use_action:
+              action: "boot"
+    slideshow: []


### PR DESCRIPTION
At last, I have implemented the Xiaomi Mi A3 (laurel_sprout) to the UBports installer. A few notes should be considered:

Two workarounds have been added regarding some issues with dtbo. The first one is an option to reflash dtbo on the "OS" section of the installer. The second is during regular installation, after flashing the system image, in which the user is prompted to reboot their device into the bootloader and flash dtbo, after which the user is prompted again to reboot into recovery to finish the installation. If users don't have any issues during a regular install, it's possible to remove the first one.

The images are currently being pulled from the UBports laurel_sprout CI and from the original kernel tree's CI (https://gitlab.com/nixeko/halium-ports/laurel_sprout/lunecrash/). We might want to move them into a more reliable host.