### PR TITLE
Implement additional fastboot actions

### DIFF
--- a/v2/schema/action.schema.yml
+++ b/v2/schema/action.schema.yml
@@ -108,6 +108,18 @@ oneOf:
       fastboot:reboot_bootloader:
         title: "fastboot:reboot_bootloader action"
         type: "null"
+  - title: fastboot:reboot_fastboot action
+    required: ["fastboot:reboot_fastboot"]
+    properties:
+      fastboot:reboot_fastboot:
+        title: "fastboot:reboot_fastboot action"
+        type: "null"
+  - title: fastboot:reboot_recovery action
+    required: ["fastboot:reboot_recovery"]
+    properties:
+      fastboot:reboot_recovery:
+        title: "fastboot:reboot_recovery action"
+        type: "null"
   - title: fastboot:update action
     required: ["fastboot:update"]
     properties:

--- a/v2/schema/action.schema.yml
+++ b/v2/schema/action.schema.yml
@@ -239,6 +239,25 @@ oneOf:
                   title: Group
                   type: string
         additionalProperties: false
+  - title: fastboot:wipe_super action
+    required: ["fastboot:wipe_super"]
+    properties:
+      fastboot:wipe_super:
+        title: "fastboot:wipe_super action"
+        type: "object"
+        properties:
+          image:
+            title: Image
+            type: object
+            properties:
+              file:
+                title: File
+                type: string
+              group:
+                title: Group
+                type: string
+        required: ["image"]
+        additionalProperties: false
   - title: fastboot:set_active action
     required: ["fastboot:set_active"]
     properties:


### PR DESCRIPTION
Devices, which are launching with Android 10 and higher, are required to implement [Dynamic Partitions](https://source.android.com/devices/tech/ota/dynamic_partitions/implement).

This requires a different workflow when installing, such as resizing super partitions or rebooting to userspace fastboot ([fastbootd](https://source.android.com/devices/bootloader/fastbootd)) mode to flash logical partitions located withing the physical super partition.

### Reboot to fastbootd mode via fastboot
```
- fastboot:reboot_fastboot:
```

### Reboot to recovery via fastboot
```
- fastboot:reboot_recovery:
```

### Wipe super partitions and repartition with specified super.img
```
- fastboot:wipe_super:
    image:
        file: "super_empty.img"
        group: "firmware"
```