### PR TITLE
schema: add "f2fs" to partition type enum

### DIFF
--- a/v2/schema/action.schema.yml
+++ b/v2/schema/action.schema.yml
@@ -195,6 +195,7 @@ oneOf:
             enum:
               - ext2
               - ext4
+              - f2fs
           size:
             title: Partition size
             type: number


### PR DESCRIPTION
This allows devices to format partitions as `f2fs`.