### PR TITLE
v2/devices: Refine Factory Reset portion for JingPad A1

### DIFF
--- a/v2/devices/jingpad_a1.yml
+++ b/v2/devices/jingpad_a1.yml
@@ -19,7 +19,8 @@ user_actions:
     button: true
   factoryreset:
     title: "Factory reset/wipe"
-    description: "Select 'Factory reset' and 'Format data/factory reset' in the recovery using the volume and power buttons."
+    description: "Select 'Factory reset' and 'Format data/factory reset' in the recovery using the volume and power buttons. Please select the 'Advanced' menu and 'Reboot to recovery' afterwards."
+    button: true
   support:
     title: "Support"
     description: "For details about Ubuntu Touch support for the JingPad A1, please head over to the UBports forum."


### PR DESCRIPTION
The missing button causes flash attempts with "Wipe" enabled to
stay stuck at the instruction without a button to continue.
Also instruct the user to reboot the device after wiping.