### PR TITLE
Fix updating Ubuntu Touch using the Ubports Installer.

### DIFF
--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -67,15 +67,15 @@ operating_systems:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://github.com/ubuntu-touch-miatoll/ubuntu-touch-miatoll/releases/download/20211021/recovery.img"
+                - url: "https://github.com/ubuntu-touch-miatoll/ubuntu-touch-miatoll/releases/download/stable-installer-fix/recovery.img"
                   name: "recovery.img"
                   checksum:
-                    sum: "116d7ca8a0b241665cc1b52653242f3385d28c4dcac4eafe0ba6d437570a1d48"
+                    sum: "461259015c4bdd0e8fb36c7412454f9c8c9e8ae6b1413e79598bd1c6ec0095ea"
                     algorithm: "sha256"
-                - url: "https://github.com/ubuntu-touch-miatoll/ubuntu-touch-miatoll/releases/download/20211021/dtbo.img"
+                - url: "https://github.com/ubuntu-touch-miatoll/ubuntu-touch-miatoll/releases/download/stable-installer-fix/dtbo.img"
                   name: "dtbo.img"
                   checksum:
-                    sum: "a65c5a092604eb9b7e9d92c4504c3ae8bbde33d76060923be488bc031bacff79"
+                    sum: "d408a9ecd7d2c6098cc06ec7dab03f69a532741f3626e6188d57b7557f421eb8"
                     algorithm: "sha256"
         condition:
           var: "bootstrap"


### PR DESCRIPTION
Fixes all the miatoll issues related to https://github.com/ubports/ubports-installer/issues/2147