### PR TITLE
Add assertion actions

### DIFF
--- a/v2/schema/action.schema.yml
+++ b/v2/schema/action.schema.yml
@@ -104,7 +104,17 @@ properties:
     additionalProperties: false
   systemimage:install:
     title: "systemimage:install action"
-    type: "null"
+    oneOf:
+      - type: "object"
+        ubports_installer-compatibility: ">=0.9.4-beta"
+        additionalProperties: false
+        properties:
+          verify_recovery:
+            title: "Verify Recovery"
+            type: "boolean"
+            description: "Verify that the recovery is capable of installing Ubuntu Touch by asserting that `adb getprop ro.ubuntu.recovery`. Defaults to false."
+      - type: "null"
+        ubports_installer-compatibility: ">=0.9.2-beta"
   asteroid_os:download:
     title: "asteroid_os:download action"
     type: "null"
@@ -209,6 +219,24 @@ properties:
         type: "string"
         enum: ["a", "b"]
     additionalProperties: false
+  fastboot:assert_var:
+    title: "fastboot:assert_var"
+    type: "object"
+    additionalProperties: false
+    oneOf:
+      - required: ["variable", "value"]
+      - required: ["variable", "regex"]
+    properties:
+      variable:
+        title: "Variable"
+        type: "string"
+        description: "Variable to assert using fastboot getvar"
+      value:
+        title: "Value"
+        type: "string"
+        description: "Asserted variable value"
+      regex:
+        $ref: regex.schema.yml#
   adb:shell:
     title: "adb:shell action"
     type: "object"
@@ -281,7 +309,27 @@ properties:
       - group
     additionalProperties: false
   adb:preparesystemimage:
+    title: "adb:preparesystemimage action"
     type: "null"
+  adb:assert_prop:
+    title: "adb:assert_prop action"
+    type: "object"
+    additionalProperties: false
+    oneOf:
+      - required: ["prop", "value"]
+      - required: ["prop", "regex"]
+    properties:
+      prop:
+        title: "Property"
+        type: "string"
+        description: "Property to assert using adb getprop"
+      value:
+        title: "Value"
+        type: "string"
+        description: "Asserted property value"
+      regex:
+        $ref: regex.schema.yml#
+    ubports_installer-compatibility: ">=0.9.4-beta"
   core:download:
     title: "core:download action"
     type: "object"

--- a/v2/schema/regex.schema.yml
+++ b/v2/schema/regex.schema.yml
@@ -1,0 +1,17 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "v2/schema/regex.schema.yml"
+title: "Regular Expression"
+type: "object"
+description: "RegEx Object"
+additionalProperties: false
+required: ["pattern"]
+properties:
+  pattern:
+    title: "RegEx Pattern"
+    type: "string"
+    description: "JS RegEx pattern to match"
+  flags:
+    title: "RegEx Flags"
+    type: "string"
+    enum: ["i", "g", "s", "m", "y", "u"]
+    description: "JS RegEx flags"


### PR DESCRIPTION
Required for https://github.com/ubports/ubports-installer/issues/2505. Will be implemented in https://github.com/ubports/ubports-installer/pull/2529.

Example:
```yml
        - adb:assert_prop:
            prop: "ro.ubuntu.recovery"
            value: "true"
        - fastboot:assert_var:
            variable: "ro.ubuntu.recovery"
            value: "true"
        - adb:assert_prop:
            prop: "ro.ubuntu.recovery"
            regex:
              pattern: "true"
              flags: "i"
        - fastboot:assert_var:
            variable: "ro.ubuntu.recovery"
            regex:
              pattern: "true"
              flags: "i"
        - systemimage:install:
              verify_recovery: true
```