### PR TITLE
Remove redundant bootloader unlock instructions

### DIFF
--- a/v2/devices/FP3.yml
+++ b/v2/devices/FP3.yml
@@ -11,10 +11,6 @@ user_actions:
     title: "Confirm OS version"
     description: "Your device must be running the Fairphone OS version of Android 10 before installing Ubuntu Touch. With a previously installed /e/ OS, it won't work! Only if it is already running the previous Halium 9 version of Ubuntu Touch and you want to upgrade to the Halium 10 (recommended), you can download and flash the Android 10 stock rom from the link below (More...), which leaves your userdata partition untouched. Afterwards run this installer again."
     link: "https://androidfilehost.com/?fid=7161016148664787652"
-  unlock_bootloader:
-    title: "Unlock your phone"
-    description: 'Your device must be "unlocked" in order to be able to flash it. Unlocking the bootloader will delete your personal data! Please check the link below (More...) and follow the instructions. If your bootloader is already unlocked, you can skip the step.'
-    link: "https://www.fairphone.com/en/bootloader-unlocking-code-for-fairphone-3"
   bootloader:
     title: "Reboot to Bootloader"
     description: "With the device powered off, press and hold the VOLUME DOWN and POWER buttons at the same time until the phone vibrates. After some seconds you'll see the fastboot mode. Or just reboot and press and hold VOLUME DOWN BUTTON while rebooting."
@@ -28,11 +24,11 @@ user_actions:
 unlock:
   - "confirm_model"
   - "confirm_os"
-  - "unlock_bootloader"
 handlers:
   bootloader_locked:
     actions:
       - fastboot:oem_unlock:
+          code_url: "https://www.fairphone.com/en/bootloader-unlocking-code-for-fairphone-3"
 operating_systems:
   - name: "Ubuntu Touch"
     compatible_installer: ">=0.9.2-beta"

--- a/v2/devices/X605.yml
+++ b/v2/devices/X605.yml
@@ -11,9 +11,6 @@ user_actions:
     title: "Confirm OS version"
     description: "Your device must be running Android 9 before installing Ubuntu Touch. This seems to be already the case for the most devices of this type. But if you still need to flash the Android 9 stock rom, please see the install section in the link below:"
     link: "https://gitlab.com/ubports/community-ports/android9/lenovo-tab-m10-fhd/lenovo-x605#install"
-  unlock_bootloader:
-    title: "Unlock your device"
-    description: 'Unlock the device bootloader following usual unlock procedure (enable Developer mode, turn on "OEM unlocking" option, then reboot to bootloader and execute `fastboot flashing unlock`. If your bootloader is already unlocked, you can skip this step.'
   bootloader:
     title: "Reboot to Bootloader"
     description: "With the device powered off, press and hold the VOLUME DOWN and POWER buttons at the same time until the device turns on. The bootloader mode is indicated by the red 'Fastboot Mode' text in the left down corner."
@@ -34,7 +31,6 @@ user_actions:
 unlock:
   - "confirm_model"
   - "confirm_os"
-  - "unlock_bootloader"
 handlers:
   bootloader_locked:
     actions:

--- a/v2/devices/axolotl.yml
+++ b/v2/devices/axolotl.yml
@@ -11,10 +11,6 @@ user_actions:
     title: "Confirm OS version"
     description: "Please double-check that your device is running the latest available stock Android 10 firmware (type: release)."
     link: "https://downloads.shiftphones.com/axolotl"
-  unlock_bootloader:
-    title: "Unlock your phone"
-    description: 'Your device must be "unlocked" in order to be able to flash it. Unlocking the bootloader will delete your personal data!<br><br>If your bootloader is already unlocked, you are good to go. Otherwise please check the link below (More...) and follow the instructions.'
-    link: "https://wiki.lineageos.org/devices/axolotl/install#unlocking-the-bootloader"
   bootloader:
     title: "Reboot to Bootloader"
     description: "With the device powered off, hold Volume Up + Power."
@@ -28,7 +24,6 @@ user_actions:
 unlock:
   - "confirm_model"
   - "confirm_os"
-  - "unlock_bootloader"
 handlers:
   bootloader_locked:
     actions:


### PR DESCRIPTION
Looks like we'll have to communicate the existing features like `code_url` better. Hacks like these should not be in the configs! They are poorly accessible, redundant, and only create confusion. Worst case, they go out of date.