### PR TITLE
lancelot: Add support for european variant "galahad"

### DIFF
--- a/v2/devices/lancelot.yml
+++ b/v2/devices/lancelot.yml
@@ -1,6 +1,6 @@
 name: "Xiaomi Redmi 9 and 9 Prime"
 codename: "lancelot"
-aliases: []
+aliases: ["galahad"]
 formfactor: "phone"
 doppelgangers: []
 user_actions:


### PR DESCRIPTION
The config for lancelot didn't contain the alias for the european variant of Redmi 9. The only thing separating them is that the european variant does have a NFC module and a different codename.