### PR TITLE
[miatoll.yml] Add Droidian configs

### DIFF
--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -29,6 +29,14 @@ user_actions:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
     link: "https://en.miui.com/unlock/"
+  datawarning:
+    title: "All your userdata will be lost"
+    description: "Flashing Droidian will wipe all the data saved on the device including your personal files. Please backup everything before continuing!"
+    button: true
+  droidian_alpha:
+    title: "Alpha quality software"
+    description: "Remember that Droidian is alpha quality software, absolutely not daily driver ready. If you break your device, you get to keep both pieces!"
+    button: true
 unlock:
   - "confirm_model"
   - "confirm_firmware"
@@ -133,4 +141,64 @@ operating_systems:
         fallback:
           - core:user_action:
               action: "recovery"
+    slideshow: []
+
+  - name: "Droidian (Alpha)"
+    compatible_installer: ">=0.9.2-beta"
+    options:
+      - var: "variant"
+        name: "Variant"
+        tooltip: "The Graphical Shell to install"
+        type: "select"
+        values:
+          - value: "phosh"
+            label: "Phosh"
+      - var: "yes"
+        name: "I'm aware all my data will be lost after flashing."
+        tooltip: "Check the box above to continue."
+        type: "checkbox"
+    prerequisites:
+      - "datawarning"
+      - "droidian_alpha"
+    steps:
+      - actions:
+        - core:download:
+            group: "firmware"
+            files:
+              - url: "https://github.com/miatoll-linux/droidian/releases/download/ubports-installer/droidian-UNOFFICIAL_miatoll-arm64-phosh-phone-29.zip"
+        condition:
+          var: "variant"
+          value: "phosh"
+      - actions:
+        - core:unpack:
+            group: "firmware"
+            files:
+              - archive: "droidian-UNOFFICIAL_miatoll-arm64-phosh-phone-29.zip"
+                dir: "unpacked_droidian"
+        condition:
+          var: "variant"
+          value: "phosh"
+      - actions:
+        - adb:reboot:
+            to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+      - actions:
+        - fastboot:flash:
+            partitions:
+              - partition: "boot"
+                file: "unpacked_droidian/data/boot.img"
+                group: "firmware"
+              - partition: "dtbo"
+                file: "unpacked_droidian/data/dtbo.img"
+                group: "firmware"
+              - partition: "userdata"
+                file: "unpacked_droidian/data/userdata.img"  
+                group: "firmware"
+        condition:
+          var: "yes"
+          value: true
+      - actions:
+          - fastboot:reboot:
     slideshow: []


### PR DESCRIPTION
Adds the possibility to flash droidian on miatoll devices using ubports installer