### PR TITLE
v2: schema: operating_systems: add field for codename

### DIFF
--- a/v2/schema/operating_systems.schema.yml
+++ b/v2/schema/operating_systems.schema.yml
@@ -18,6 +18,10 @@ items:
       title: OS name
       type: "string"
       description: "Human-readable name of the operating system."
+    codename:
+      title: Codename of the device
+      type: "string"
+      description: "Codename of the device as used by the operating system."
     compatible_installer:
       title: Compatible Installer
       type: "string"


### PR DESCRIPTION
This adds a field "codename" to the operating_systems section, which can be used to specify the codename of the device if the config specified value differs from the value used by the OS.

This is required for the Fairphone 4 and the postmarketOS plugin, as the config specifies "FP4" but the postmarketOS API requires "fairphone-fp4".

/cc @z3ntu