### PR TITLE
volla-yggdrasil: Remove alias

### DIFF
--- a/v2/devices/yggdrasil.yml
+++ b/v2/devices/yggdrasil.yml
@@ -1,8 +1,7 @@
-name: "VollaPhone"
+name: "Volla Phone"
 codename: "yggdrasil"
 formfactor: "phone"
-aliases:
-  - "k63v2_64_bsp"
+aliases: []
 doppelgangers: []
 user_actions:
   recovery:


### PR DESCRIPTION
This caused Volla Phone X (`yggdrasilx`) to be detected as Volla Phone (`yggdrasil`) while in bootloader mode (`fastboot`) and continuing with the flashing would soft-brick the device until reflashed with the correct firmware using low level SP flash tool.

Potentially fixes https://github.com/ubports/ubports-installer/issues/2833.