### PR TITLE
devices: Add installer config for Fxtec Pro1 X (pro1x)

### DIFF
--- a/v2/devices/pro1.yml
+++ b/v2/devices/pro1.yml
@@ -1,8 +1,8 @@
-name: "F(x)tec Pro1/Pro1 X"
+name: "F(x)tec Pro1"
 codename: "pro1"
 formfactor: "phone"
 aliases: []
-doppelgangers: []
+doppelgangers: ["pro1x"]
 user_actions:
   bootloader:
     title: "Reboot to Bootloader"

--- a/v2/devices/pro1x.yml
+++ b/v2/devices/pro1x.yml
@@ -1,0 +1,175 @@
+name: "F(x)tec Pro1 X"
+codename: "pro1x"
+formfactor: "phone"
+aliases: []
+doppelgangers: ["pro1"]
+user_actions:
+  confirm_model:
+    title: "Confirm your model"
+    description: "Please check that your device is a Fairphone 4 (FP4)."
+  confirm_os:
+    title: "Confirm OS version"
+    description: "Your device must be running the official version of Android 11 before installing Ubuntu Touch. With a previously installed custom ROM, it won't work!"
+  unlock_phone:
+    title: "Unlock the bootloader"
+    description: "Before installing Ubuntu Touch you must unlock the bootloader of your phone manually. Follow the steps in the linked page if you haven't already."
+    link: "https://community.fxtec.com/topic/3617-pro1-x-oembootloader-lock-user-manual/"
+  bootloader:
+    title: "Reboot to Bootloader"
+    description: "With the device powered off, press and hold the VOLUME DOWN button and plug the device into your PC via USB. After some seconds you'll see the fastboot mode."
+    image: "phone_power_down"
+    button: true
+  bootloader_from_fastbootd:
+    title: "Reboot to Bootloader"
+    description: 'With the device still at the fastbootd screen, use the volume buttons to select "Reboot to bootloader".'
+    image: "phone_power_down"
+    button: true
+  recovery:
+    title: "Reboot to Recovery"
+    description: 'With the device still at the "FastBoot Mode", use the Volume buttons to switch to "Recovery Mode" and push the power button to confirm your selection.'
+    image: "phone_power_up"
+    button: true
+  fastbootd:
+    title: "Reboot to fastbootd mode"
+    description: 'With the device still at the "FastBoot Mode", use the Volume buttons to switch to "Recovery Mode" and push the power button to confirm your selection. Then select "Fastboot mode" from the list.'
+    image: "phone_power_up"
+    button: true
+unlock:
+  - "confirm_model"
+  - "confirm_os"
+  - "unlock_phone"
+operating_systems:
+  - name: "Ubuntu Touch"
+    compatible_installer: ">=0.9.6-beta"
+    options:
+      - var: "channel"
+        name: "Channel"
+        tooltip: "The release channel"
+        link: "https://docs.ubports.com/en/latest/about/process/release-schedule.html"
+        type: "select"
+        remote_values:
+          systemimage:channels:
+      - var: "wipe"
+        name: "Wipe Userdata"
+        tooltip: "Wipe personal data. This is necessary for first time installations."
+        type: "checkbox"
+      - var: "partition"
+        name: "Partitioning"
+        tooltip: "Changes partition sizes as required. Only necessary for first time installations."
+        type: "checkbox"
+        value: true
+      - var: "bootstrap"
+        name: "Bootstrap"
+        tooltip: "Flash system partitions using fastboot"
+        type: "checkbox"
+        value: true
+    prerequisites: []
+    steps:
+      ### Ensure we always start in bootloader mode
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+      ### Ensure the bootloader has been unlocked already
+      - actions:
+          - fastboot:wait:
+      - actions:
+          - fastboot:assert_var:
+              variable: "unlocked"
+              value: "yes"
+        fallback:
+          - core:user_action:
+              action: "unlock_phone"
+      ### As this is an A/B device, force all future operations in "a" slot.
+      - actions:
+          - fastboot:set_active:
+              slot: "a"
+      ### Flash important partitions (if requested)
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://cdimage.ubports.com/devices/pro1x/recovery.img"
+                  checksum:
+                    sum: "8b5dcac087a6856492c873bc73ab8714d81bb7a61c29519d8a59bb38bcaaabfe"
+                    algorithm: "sha256"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "recovery"
+                  file: "recovery.img"
+                  group: "firmware"
+                  raw: true
+        condition:
+          var: "bootstrap"
+          value: true
+      ### Set up logical partitions (if requested)
+      - actions:
+          - fastboot:reboot_fastboot:
+        fallback:
+          - core:user_action:
+              action: "fastbootd"
+        condition:
+          var: "partition"
+          value: true
+      - actions:
+          # Remove all unused logical partitions
+          - fastboot:delete_logical_partition:
+              partition: "system_ext_a"
+          - fastboot:delete_logical_partition:
+              partition: "system_ext_b"
+          - fastboot:delete_logical_partition:
+              partition: "product_a"
+          - fastboot:delete_logical_partition:
+              partition: "product_b"
+          # Remove _b variants of used partitions
+          - fastboot:delete_logical_partition:
+              partition: "system_b"
+          - fastboot:delete_logical_partition:
+              partition: "vendor_b"
+          - fastboot:delete_logical_partition:
+              partition: "odm_b"
+          # Increase space for system_a for UT installation
+          - fastboot:resize_logical_partition:
+              partition: "system_a"
+              size: 3221225472
+        condition:
+          var: "partition"
+          value: true
+      - actions:
+          - fastboot:reboot_bootloader:
+        fallback:
+          - core:user_action:
+              action: "bootloader_from_fastbootd"
+        condition:
+          var: "partition"
+          value: true
+      ### Wipe userdata (if requested)
+      - actions:
+          - fastboot:format:
+              partition: "userdata"
+              type: "ext4"
+        condition:
+          var: "wipe"
+          value: true
+      ### Systemimage installation steps
+      - actions:
+          - fastboot:reboot_recovery:
+        fallback:
+          - core:user_action:
+              action: "recovery"
+      - actions:
+          - systemimage:install:
+              verify_recovery: true
+      - actions:
+          - adb:reboot:
+              to_state: "recovery"
+        fallback:
+          - core:user_action:
+              action: "recovery"
+    slideshow: []


### PR DESCRIPTION
This adds installer config for the newer Fxtec Pro1 X and removes erroneous mention of Pro1 X from the original Pro1 config. 

Please upload https://gitlab.com/ubports/porting/community-ports/android11/fxtec-pro1x/fxtec-pro1x/-/jobs/4181610683/artifacts/raw/out/recovery.img to https://cdimage.ubports.com/devices/pro1x/recovery.img