### PR TITLE
mimameid: Add Droidian support

### DIFF
--- a/v2/devices/mimameid.yml
+++ b/v2/devices/mimameid.yml
@@ -17,6 +17,10 @@ user_actions:
     title: "Reboot the device"
     description: "Hold down the power button until the device powers down. Then, release it briefly and hold it down again until the device boots."
     button: true
+  cutie_notice:
+    title: "Cutie Shell: Notice"
+    description: "You selected to install Droidian with Cutie Shell. Cutie Shell is still pre-alpha quality and it is not suitable for production environments. Keep in mind that Cutie Shell is not officially supported or endorsed by Droidian. This edition is maintained directly by Cutie Shell Community Project and you should report any bugs with these images at Cutie Shell Community Project before filing upstream."
+    button: true
 unlock: []
 handlers:
   bootloader_locked:
@@ -216,3 +220,131 @@ operating_systems:
       title: "EULA"
       description: "THE TERMS OF USE OF THE VOLLA OS ONLY ALLOW AN INSTALLATION ON A CLEARLY BRANDED VOLLA PHONE 22. To proceed with the installation you have to confirm that you have read and understood the End User License Agreement (EULA) of Hallo Welt Systeme UG (haftungsbeschränkt) for the Volla OS and agree to it."
       link: "https://volla.online/en/eula/index.html"
+  - name: "Droidian"
+    compatible_installer: ">=0.9.2-beta"
+    options:
+      - var: "variant"
+        name: "Variant"
+        tooltip: "The graphical shell to install"
+        type: "select"
+        values:
+          - value: "phosh"
+            label: "Phosh"
+          - value: "cutie"
+            label: "Cutie Shell"
+      - var: "bootstrap"
+        name: "Bootstrap"
+        tooltip: "Flash system partitions using fastboot"
+        type: "checkbox"
+        value: true
+    prerequisites: []
+    steps:
+      - actions:
+          - core:user_action:
+              action: "cutie_notice"
+        condition:
+          var: "variant"
+          value: "cutie"
+      # Firmware setup (bootstrap)
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://volla.tech/filedump/volla-mimameid-11.0-ubports-installer-bootstrap.zip"
+                  checksum:
+                    sum: "c0216239cc6dc11e23940884d0f6d1183b29898e63b561da8122bf69636f6c7c"
+                    algorithm: "sha256"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "volla-mimameid-11.0-ubports-installer-bootstrap.zip"
+                  dir: "unpacked"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://images.droidian.org/droidian/nightly/arm64/volla/image-fastboot-mimameid.zip"
+        condition:
+          var: "variant"
+          value: "phosh"
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://github.com/cutie-shell/droidian/releases/download/nightly/droidian-OFFICIAL_volla_mimameid-arm64-cutie-phone-30.zip"
+        condition:
+          var: "variant"
+          value: "cutie"
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "image-fastboot-mimameid.zip"
+                  dir: "unpacked_droidian"
+        condition:
+          var: "variant"
+          value: "phosh"
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "droidian-OFFICIAL_volla_mimameid-arm64-cutie-phone-30.zip"
+                  dir: "unpacked_droidian"
+        condition:
+          var: "variant"
+          value: "cutie"
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:set_active:
+              slot: "a"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "lk_a"
+                  file: "unpacked/lk.img"
+                  group: "firmware"
+                - partition: "lk_b"
+                  file: "unpacked/lk.img"
+                  group: "firmware"
+                - partition: "super"
+                  file: "unpacked/super.img"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "dtbo"
+                  file: "unpacked_droidian/data/dtbo.img"
+                  group: "firmware"
+                - partition: "boot"
+                  file: "unpacked_droidian/data/boot.img"
+                  group: "firmware"
+                - partition: "vbmeta"
+                  file: "unpacked_droidian/data/vbmeta.img"
+                  group: "firmware"
+                - partition: "userdata"
+                  file: "unpacked_droidian/data/userdata.img"
+                  group: "firmware"
+      - actions:
+          - fastboot:reboot:
+    slideshow: []


### PR DESCRIPTION
mimameid has now official support on Droidian and is built on the official Droidian CI. Also, Droidian/Cutie is working and built by Cutie CI.

This PR adds the possibility to install these Droidian images either with phosh or Cutie on Volla Phone 22.