### PR TITLE
angelica/lavender/onclite: Use official Droidian download and add Cutie option

### DIFF
--- a/v2/devices/angelica.yml
+++ b/v2/devices/angelica.yml
@@ -30,6 +30,10 @@ user_actions:
     description: 'With the device still at the "FastBoot Mode", use the Volume buttons to switch to "Recovery Mode" and push the power button to confirm your selection. Then select "Fastboot mode" from the list.'
     image: "phone_power_up"
     button: true
+  cutie_notice:
+    title: "Cutie Shell: Notice"
+    description: "You selected to install Droidian with Cutie Shell. Cutie Shell is still pre-alpha quality and it is not suitable for production environments. Keep in mind that Cutie Shell is not officially supported or endorsed by Droidian. This edition is maintained directly by Cutie Shell Community Project and you should report any bugs with these images at Cutie Shell Community Project before filing upstream."
+    button: true
 unlock:
   - "confirm_model"
   - "confirm_os"
@@ -173,13 +177,38 @@ operating_systems:
         values:
           - value: "phosh"
             label: "Phosh"
+          - value: "cutie"
+            label: "Cutie Shell"
     prerequisites: []
     steps:
+      - actions:
+          - core:user_action:
+              action: "cutie_notice"
+        condition:
+          var: "variant"
+          value: "cutie"
       - actions:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://github.com/droidian-mt6765/droidian-images-angelica/releases/download/ubports-installer/droidian-UNOFFICIAL_xiaomi_angelica-armhf-phosh-phone-29.zip"
+                - url: "https://images.droidian.org/droidian/nightly/armhf/xiaomi/image-fastboot-angelica.zip"
+        condition:
+          var: "variant"
+          value: "phosh"
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://github.com/cutie-shell/droidian/releases/download/nightly/droidian-OFFICIAL_xiaomi_angelica-armhf-cutie-phone-29.zip"
+        condition:
+          var: "variant"
+          value: "cutie"
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "image-fastboot-angelica.zip"
+                  dir: "unpacked_droidian"
         condition:
           var: "variant"
           value: "phosh"
@@ -187,11 +216,11 @@ operating_systems:
           - core:unpack:
               group: "firmware"
               files:
-                - archive: "droidian-UNOFFICIAL_xiaomi_angelica-armhf-phosh-phone-29.zip"
+                - archive: "droidian-OFFICIAL_xiaomi_angelica-armhf-cutie-phone-29.zip"
                   dir: "unpacked_droidian"
         condition:
           var: "variant"
-          value: "phosh"
+          value: "cutie"
       - actions:
           - adb:reboot:
               to_state: "bootloader"

--- a/v2/devices/lavender.yml
+++ b/v2/devices/lavender.yml
@@ -26,6 +26,10 @@ user_actions:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
     link: "https://en.miui.com/unlock/"
+  cutie_notice:
+    title: "Cutie Shell: Notice"
+    description: "You selected to install Droidian with Cutie Shell. Cutie Shell is still pre-alpha quality and it is not suitable for production environments. Keep in mind that Cutie Shell is not officially supported or endorsed by Droidian. This edition is maintained directly by Cutie Shell Community Project and you should report any bugs with these images at Cutie Shell Community Project before filing upstream."
+    button: true
 unlock:
   - "confirm_model"
   - "unlock"
@@ -175,13 +179,38 @@ operating_systems:
         values:
           - value: "phosh"
             label: "Phosh"
+          - value: "cutie"
+            label: "Cutie Shell"
     prerequisites: []
     steps:
+      - actions:
+          - core:user_action:
+              action: "cutie_notice"
+        condition:
+          var: "variant"
+          value: "cutie"
       - actions:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://github.com/droidian-lavender/droidian-images/releases/download/ubports-installer/droidian-UNOFFICIAL_xiaomi_lavender-arm64-phosh-phone-28.zip"
+                - url: "https://images.droidian.org/droidian/nightly/arm64/xiaomi/image-fastboot-lavender.zip"
+        condition:
+          var: "variant"
+          value: "phosh"
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://github.com/cutie-shell/droidian/releases/download/nightly/droidian-OFFICIAL_xiaomi_lavender-arm64-cutie-phone-28.zip"
+        condition:
+          var: "variant"
+          value: "cutie"
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "image-fastboot-lavender.zip"
+                  dir: "unpacked_droidian"
         condition:
           var: "variant"
           value: "phosh"
@@ -189,11 +218,11 @@ operating_systems:
           - core:unpack:
               group: "firmware"
               files:
-                - archive: "droidian-UNOFFICIAL_xiaomi_lavender-arm64-phosh-phone-28.zip"
+                - archive: "droidian-OFFICIAL_xiaomi_lavender-arm64-cutie-phone-28.zip"
                   dir: "unpacked_droidian"
         condition:
           var: "variant"
-          value: "phosh"
+          value: "cutie"
       - actions:
           - adb:reboot:
               to_state: "bootloader"

--- a/v2/devices/onclite.yml
+++ b/v2/devices/onclite.yml
@@ -22,6 +22,10 @@ user_actions:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
     link: "https://en.miui.com/unlock/"
+  cutie_notice:
+    title: "Cutie Shell: Notice"
+    description: "You selected to install Droidian with Cutie Shell. Cutie Shell is still pre-alpha quality and it is not suitable for production environments. Keep in mind that Cutie Shell is not officially supported or endorsed by Droidian. This edition is maintained directly by Cutie Shell Community Project and you should report any bugs with these images at Cutie Shell Community Project before filing upstream."
+    button: true
 unlock:
   - "confirm_model"
   - "unlock"
@@ -152,13 +156,38 @@ operating_systems:
         values:
           - value: "phosh"
             label: "Phosh"
+          - value: "cutie"
+            label: "Cutie Shell"
     prerequisites: []
     steps:
+      - actions:
+          - core:user_action:
+              action: "cutie_notice"
+        condition:
+          var: "variant"
+          value: "cutie"
       - actions:
           - core:download:
               group: "firmware"
               files:
-                - url: "https://github.com/droidian-onclite/droidian-images/releases/download/ubports-installer/droidian-UNOFFICIAL_xiaomi_onclite-arm64-phosh-phone-28.zip"
+                - url: "https://images.droidian.org/droidian/nightly/arm64/xiaomi/image-fastboot-onclite.zip"
+        condition:
+          var: "variant"
+          value: "phosh"
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://github.com/cutie-shell/droidian/releases/download/nightly/droidian-OFFICIAL_xiaomi_onclite-arm64-cutie-phone-28.zip"
+        condition:
+          var: "variant"
+          value: "cutie"
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "image-fastboot-onclite.zip"
+                  dir: "unpacked_droidian"
         condition:
           var: "variant"
           value: "phosh"
@@ -166,11 +195,11 @@ operating_systems:
           - core:unpack:
               group: "firmware"
               files:
-                - archive: "droidian-UNOFFICIAL_xiaomi_onclite-arm64-phosh-phone-28.zip"
+                - archive: "droidian-OFFICIAL_xiaomi_onclite-arm64-cutie-phone-28.zip"
                   dir: "unpacked_droidian"
         condition:
           var: "variant"
-          value: "phosh"
+          value: "cutie"
       - actions:
           - adb:reboot:
               to_state: "bootloader"


### PR DESCRIPTION
On these devices, the Droidian download URLs should be updated as the devices have been moved to official status. Also, similarly to other devices, adding Cutie as an option alongside phosh should be done.