### PR TITLE
vidofnir: Ensure UT userdata is formatted as ext4

### DIFF
--- a/v2/devices/vidofnir.yml
+++ b/v2/devices/vidofnir.yml
@@ -103,6 +103,7 @@ operating_systems:
       - actions:
           - fastboot:format:
               partition: "userdata"
+              type: "ext4"
         condition:
           var: "wipe"
           value: true


### PR DESCRIPTION
Otherwise there will be problems during install since `f2fs` isn't specified in recovery `fstab` etc.

Fixes https://github.com/ubports/installer-configs/pull/240#issuecomment-1668697513.