### PR TITLE
Update miatoll.yml recovery and dtbo SHA

### DIFF
--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -74,12 +74,12 @@ operating_systems:
                 - url: "https://github.com/ubuntu-touch-miatoll/ubuntu-touch-miatoll/releases/download/stable-installer-fix/recovery.img"
                   name: "recovery.img"
                   checksum:
-                    sum: "461259015c4bdd0e8fb36c7412454f9c8c9e8ae6b1413e79598bd1c6ec0095ea"
+                    sum: "e03f68c4769d68e1437de6fb3de6bcb996c12eba6b442962b41e7a6441513c7e"
                     algorithm: "sha256"
                 - url: "https://github.com/ubuntu-touch-miatoll/ubuntu-touch-miatoll/releases/download/stable-installer-fix/dtbo.img"
                   name: "dtbo.img"
                   checksum:
-                    sum: "d408a9ecd7d2c6098cc06ec7dab03f69a532741f3626e6188d57b7557f421eb8"
+                    sum: "d000f2c07571b6b007836cfdb2ea998b2e709504e34598a7f09259f6a50be8b3"
                     algorithm: "sha256"
         condition:
           var: "bootstrap"


### PR DESCRIPTION
The recovery and dtbo images were updated so this commit is to update their SHA checksum