### PR TITLE
surya: Add support for indian variant

### DIFF
--- a/v2/devices/surya.yml
+++ b/v2/devices/surya.yml
@@ -1,6 +1,7 @@
 name: "Xiaomi Poco X3 NFC"
 codename: "surya"
-aliases: []
+aliases:
+  - "karna"
 formfactor: "phone"
 doppelgangers: []
 user_actions:


### PR DESCRIPTION
Currently, Xiaomi POCO X3 (karna) and Xiaomi POCO X3 NFC (surya) use the same images (system and kernel) and the same [device page](https://devices.ubuntu-touch.io/device/surya/).
But only surya is installable with the UBports installer.
As suggested at https://t.me/ut_pocox3/13719, this MR add support for the indian variant (karna).