### PR TITLE
miatoll: resize partition of system

### DIFF
--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -127,7 +127,7 @@ operating_systems:
           # Increase space for system_a for UT installation
           - fastboot:resize_logical_partition:
               partition: "system"
-              size: 3221225472
+              size: 3670016000
         condition:
           var: "partition"
           value: true


### PR DESCRIPTION
in order to install utnext, partition with system has to be a little bigger, using 3500MiB as suggested by JamiKettunen tested on joyeuse