### PR TITLE
Update boot image

### DIFF
--- a/v2/devices/amar_row_lte.yml
+++ b/v2/devices/amar_row_lte.yml
@@ -90,7 +90,7 @@ operating_systems:
               files:
                 - url: "https://github.com/rubencarneiro/amar_row_lte/releases/download/1.0/boot.img"
                   checksum:
-                    sum: "4161f2f63c85fb462f555e3cf87e73ae2080d51d8d858359360151af372a9c7d"
+                    sum: "f3f373f44a8f5e5077965b58fddad28fa01202642e75c386985ecabe76e31618"
                     algorithm: "sha256"
                 - url: "https://github.com/rubencarneiro/amar_row_lte/releases/download/1.0/recovery.img"
                   checksum:

--- a/v2/devices/amar_row_wifi.yml
+++ b/v2/devices/amar_row_wifi.yml
@@ -90,7 +90,7 @@ operating_systems:
               files:
                 - url: "https://github.com/rubencarneiro/amar_row_wifi/releases/download/1.0/boot.img"
                   checksum:
-                    sum: "d2410a0a730ceeeef19d30773dabe118c818af006c3c52e960b3aeee87cfa9c5"
+                    sum: "e6acba8552d96b26582db364513364b0bf733a78ed1b9e262e5001f43e43e6ed"
                     algorithm: "sha256"
                 - url: "https://github.com/rubencarneiro/amar_row_wifi/releases/download/1.0/recovery.img"
                   checksum:

--- a/v2/devices/billie.yml
+++ b/v2/devices/billie.yml
@@ -94,7 +94,7 @@ operating_systems:
               files:
                 - url: "https://github.com/rubencarneiro/billie/releases/download/1.0/boot.img"
                   checksum:
-                    sum: "04770c80896f6d73fe7055da6e745946fc673b1f7351c2f725b4a8567de41111"
+                    sum: "b5f3cd9f708ff986fe0cfb95ac47a4222c456a6d476279409c6c2417eda50234"
                     algorithm: "sha256"
                 - url: "https://github.com/rubencarneiro/billie/releases/download/1.0/recovery.img"
                   checksum:

--- a/v2/devices/billie2.yml
+++ b/v2/devices/billie2.yml
@@ -94,7 +94,7 @@ operating_systems:
               files:
                 - url: "https://github.com/rubencarneiro/billie2/releases/download/1.0/boot.img"
                   checksum:
-                    sum: "9558a382154ecccbf0fcac75dd13f4865523158d86e347b05a46511139dedaab"
+                    sum: "708eef1027b45234a2eb31b9ce6cf0f1a7ecba55d2c78c9f26032aa40dc683c3"
                     algorithm: "sha256"
                 - url: "https://github.com/rubencarneiro/billie2/releases/download/1.0/recovery.img"
                   checksum:


### PR DESCRIPTION
Update boot image with repatched AppArmor to allow to boot 24.04
- add required instrictions for snapd and systemd
- Oneplus Nord N10 (billie)
- OnePlus Nord N100 (billie2)
- Lenovo Tab M10 HD Wifi (amarrow_wifi)
- Lenovo Tab M10 HD LTE (amare_row_lte)