### PR TITLE
devices: Add config for Fairphone (Gen. 6)

### DIFF
--- a/v2/devices/FP6.yml
+++ b/v2/devices/FP6.yml
@@ -1,0 +1,80 @@
+name: "Fairphone (Gen. 6)"
+codename: "FP6"
+formfactor: "phone"
+aliases: ["fp6"]
+doppelgangers: []
+user_actions:
+  confirm_model:
+    title: "Confirm your model"
+    description: "Please check that your device is a Fairphone (Gen. 6) (FP6)."
+  unlock_phone:
+    title: "Unlock the bootloader"
+    description: "Before installing another operating system you must unlock the bootloader of your phone manually. Follow the steps in the linked page if you haven't already."
+    link: "https://support.fairphone.com/hc/en-us/articles/10492476238865-Manage-the-Bootloader"
+  bootloader:
+    title: "Reboot to Bootloader"
+    description: "With the device powered off, press and hold the VOLUME DOWN button and plug the device into your PC via USB. After some seconds you'll see the fastboot mode."
+    image: "phone_power_down"
+    button: true
+unlock:
+  - "confirm_model"
+  - "unlock_phone"
+operating_systems:
+  - name: "postmarketOS"
+    codename: "fairphone-fp6"
+    compatible_installer: ">=0.9.8-beta"
+    options:
+      - var: "release"
+        name: "Release"
+        tooltip: "The postmarketOS release"
+        link: "https://wiki.postmarketos.org/wiki/Releases"
+        type: "select"
+        remote_values:
+          postmarketos:releases:
+      - var: "interface"
+        name: "User Interface"
+        tooltip: "The user interface"
+        link: "https://wiki.postmarketos.org/wiki/Category:Interface"
+        type: "select"
+        remote_values:
+          postmarketos:interfaces:
+    prerequisites: []
+    steps:
+      ### Ensure we always start in bootloader mode
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+      ### Ensure the bootloader has been unlocked already
+      - actions:
+          - fastboot:wait:
+      - actions:
+          - fastboot:assert_var:
+              variable: "unlocked"
+              value: "yes"
+        fallback:
+          - core:user_action:
+              action: "unlock_phone"
+      ### As this is an A/B device, force all future operations in "a" slot.
+      - actions:
+          - fastboot:set_active:
+              slot: "a"
+      ### Flash partitions
+      - actions:
+          - postmarketos:download:
+          - fastboot:erase:
+              partition: "dtbo"
+          - fastboot:erase:
+              partition: "vendor_boot"
+          - fastboot:flash:
+              partitions:
+                - partition: "userdata"
+                  file: "rootfs.img"
+                  group: "postmarketOS"
+                - partition: "boot"
+                  file: "boot.img"
+                  group: "postmarketOS"
+          - fastboot:continue:
+    slideshow: []


### PR DESCRIPTION
Add the ability to install postmarketOS on the device using the installer.

~~Draft: prebuilt images should be built once https://gitlab.postmarketos.org/postmarketOS/build.postmarketos.org/-/merge_requests/146 is merged. Then needs some testing.~~ **edit:** Works great!