### PR TITLE
FP4, FP5: increases system_a's partition size to matches new recovery

### DIFF
--- a/v2/devices/FP4.yml
+++ b/v2/devices/FP4.yml
@@ -154,7 +154,8 @@ operating_systems:
           # Increase space for system_a for UT installation
           - fastboot:resize_logical_partition:
               partition: "system_a"
-              size: 3221225472
+              # 4500MiB - matches new recovery
+              size: 4718592000
         condition:
           var: "partition"
           value: true

--- a/v2/devices/FP5.yml
+++ b/v2/devices/FP5.yml
@@ -144,7 +144,8 @@ operating_systems:
           # Increase space for system_a for UT installation
           - fastboot:resize_logical_partition:
               partition: "system_a"
-              size: 3421225472
+              # 4500MiB - matches new recovery.
+              size: 4718592000
         condition:
           var: "partition"
           value: true


### PR DESCRIPTION
This increases make sure we have enough space when 24.04-2.x UT rootfs start including Qt 6 Morph Browser, and then some. It also matches the new size requested in the (new) recovery, which means there's no need to resize again after the first flash.