### PR TITLE
pro1x: Bump system_a resize from 3 GiB to 4500 MiB

### DIFF
--- a/v2/devices/pro1x.yml
+++ b/v2/devices/pro1x.yml
@@ -137,7 +137,8 @@ operating_systems:
           # Increase space for system_a for UT installation
           - fastboot:resize_logical_partition:
               partition: "system_a"
-              size: 3221225472
+              # 4500MiB - matches new recovery
+              size: 4718592000
         condition:
           var: "partition"
           value: true


### PR DESCRIPTION
Similar to #316; see https://gitlab.com/ubports/porting/community-ports/android11/fxtec-pro1x/fxtec-pro1x/-/commit/bb3fe27e