### PR TITLE
devices: Add initial config for Zinwa Q25

### DIFF
--- a/v2/devices/Q25.yml
+++ b/v2/devices/Q25.yml
@@ -1,0 +1,132 @@
+name: "Zinwa Q25"
+codename: "Q25"
+formfactor: "phone"
+user_actions:
+  confirm_fw:
+    title: "Confirm OS version"
+    description: "Your device must be running (ideally latest mass production) Android 14 firmware linked below on slot A before installing Ubuntu Touch. Easiest way to achieve this is by flashing the device in 'Firmware Upgrade' mode of SP Flash Tool v6 before re-unlocking the bootloader as usual."
+    link: "https://drive.zinwa.com/"
+    button: true
+  bootloader:
+    title: "Reboot to Bootloader mode"
+    description: 'With the device powered off, hold Volume Up + Power. When prompted select "Fastboot" as the boot mode using Volume Up and confirm with Volume Down.'
+    image: "phone_power_up"
+    button: true
+  recovery:
+    title: "Reboot to Recovery mode"
+    description: 'With the device powered off, hold Volume Up + Power. When prompted select "Recovery" as the boot mode using Volume Up and confirm with Volume Down.'
+    image: "phone_power_up"
+    button: true
+handlers:
+  bootloader_locked:
+    actions:
+      - fastboot:flashing_unlock:
+operating_systems:
+  - name: "Ubuntu Touch"
+    compatible_installer: ">=0.9.2-beta"
+    options:
+      - var: "channel"
+        name: "Channel"
+        tooltip: "The release channel"
+        link: "https://docs.ubports.com/en/latest/about/process/release-schedule.html"
+        type: "select"
+        remote_values:
+          systemimage:channels:
+      - var: "wipe"
+        name: "Wipe Userdata"
+        tooltip: "Wipe personal data. *Required* if switching from something (e.g. Android) that isn't Ubuntu Touch."
+        type: "checkbox"
+      - var: "bootstrap"
+        name: "Bootstrap"
+        tooltip: "Flash system partitions using fastboot. Do NOT uncheck unless you know exactly what you're doing!"
+        type: "checkbox"
+        value: true
+    prerequisites: []
+    steps:
+      - actions:
+          - core:user_action:
+              action: "confirm_fw"
+        condition:
+          var: "bootstrap"
+          value: true
+
+      # Handle initial bootstrap/userdata wipe in bootloader mode
+      ##################################################################
+      - actions:
+# FIXME: bring below back once "adb reboot bootloader" unbroken on UT side
+#          - adb:reboot:
+#              to_state: "bootloader"
+#        fallback:
+          - core:user_action:
+              action: "bootloader"
+        condition:
+          OR:
+            - var: "bootstrap"
+              value: true
+            - var: "wipe"
+              value: true
+
+      - actions:
+          # latest artifacts from https://gitlab.com/ubports/porting/community-ports/android12/zinwa-q25/zinwa-q25
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://gitlab.com/api/v4/projects/77968766/jobs/artifacts/main/download?job=build"
+                  name: "artifacts.zip"
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "artifacts.zip"
+                  dir: "unpacked"
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "unpacked/out/device_Q25.tar.xz"
+                  dir: "unpacked"
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "unpacked/device_Q25.tar"
+                  dir: "unpacked"
+        condition:
+          var: "bootstrap"
+          value: true
+
+      - actions:
+          - fastboot:set_active:
+              slot: "a"
+          - fastboot:flash:
+              partitions:
+                - partition: "boot_a"
+                  file: "unpacked/partitions/boot.img"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+
+      # Optionally wipe userdata (too)
+      - actions:
+          - fastboot:format:
+              partition: "userdata"
+              type: "ext4"
+        condition:
+          var: "wipe"
+          value: true
+
+      # Install UT
+      ##################################################################
+      - actions:
+          - fastboot:reboot_recovery:
+        fallback:
+          - core:user_action:
+              action: "recovery"
+
+      - actions:
+          - systemimage:install:
+      - actions:
+          - adb:reboot:
+              to_state: "recovery"
+        fallback:
+          - core:user_action:
+              action: "recovery"
+    slideshow: []


### PR DESCRIPTION
This is a [semi-advanced stage port](https://gitlab.com/ubports/porting/community-ports/android12/zinwa-q25/zinwa-q25) for the BlackBerry Classic (Q20) restomod using a MediaTek Helio G99 with Ubuntu Touch `24.04-2.x` and above daily system-image channels available.

Cc: @NotKit 