### PR TITLE
v2/devices: repair link leading to nowhere

### DIFF
--- a/v2/devices/begonia.yml
+++ b/v2/devices/begonia.yml
@@ -20,7 +20,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
   adb_bug:
     title: "Warning"
     description: "This device is known to have problems with adb push, so the installer will flash latest stable image. Please switch to desired channel afterwards in System Settings."

--- a/v2/devices/beryllium.yml
+++ b/v2/devices/beryllium.yml
@@ -20,7 +20,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
   warning:
     title: "Warning"
     description: "The port is based on Android 9 firmware (V11.0.5.0.PEJMIXM) and Lineage 16 vendor image. Current Recovery will be replaced with Ubports Recovery! Remember to flash the latest firmware when reverting to latest Android builds!"

--- a/v2/devices/citrus.yml
+++ b/v2/devices/citrus.yml
@@ -24,7 +24,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
 unlock:
   - "confirm_model"
   - "confirm_firmware"

--- a/v2/devices/dipper.yml
+++ b/v2/devices/dipper.yml
@@ -20,7 +20,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
   warning:
     title: "Warning"
     description: "The port is based on Android 9 firmware and vendor (V11.0.6.0.PEAMIXM). Current Recovery will be replaced with Ubports Recovery! Remember to flash the latest firmware when reverting to latest Android builds!"

--- a/v2/devices/lancelot.yml
+++ b/v2/devices/lancelot.yml
@@ -24,7 +24,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
 unlock:
   - "confirm_model"
   - "confirm_firmware"

--- a/v2/devices/land.yml
+++ b/v2/devices/land.yml
@@ -17,7 +17,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock"
+    link: "https://en.miui.com/unlock/download_en.html"
   support:
     title: "Support"
     description: "For details about Ubuntu Touch support for the Redmi 3s/3x/3sp, please head over to the UBports forum thread."

--- a/v2/devices/lavender.yml
+++ b/v2/devices/lavender.yml
@@ -25,7 +25,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
   cutie_notice:
     title: "Cutie Shell: Notice"
     description: "You selected to install Droidian with Cutie Shell. Cutie Shell is still pre-alpha quality and it is not suitable for production environments. Keep in mind that Cutie Shell is not officially supported or endorsed by Droidian. This edition is maintained directly by Cutie Shell Community Project and you should report any bugs with these images at Cutie Shell Community Project before filing upstream."

--- a/v2/devices/merlin.yml
+++ b/v2/devices/merlin.yml
@@ -24,7 +24,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
 unlock:
   - "confirm_model"
   - "confirm_firmware"

--- a/v2/devices/miatoll.yml
+++ b/v2/devices/miatoll.yml
@@ -28,7 +28,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
   cutie_notice:
     title: "Cutie Shell: Notice"
     description: "You selected to install Droidian with Cutie Shell. Cutie Shell is still pre-alpha quality and it is not suitable for production environments. Keep in mind that Cutie Shell is not officially supported or endorsed by Droidian. This edition is maintained directly by Cutie Shell Community Project and you should report any bugs with these images at Cutie Shell Community Project before filing upstream."

--- a/v2/devices/onclite.yml
+++ b/v2/devices/onclite.yml
@@ -21,7 +21,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
   cutie_notice:
     title: "Cutie Shell: Notice"
     description: "You selected to install Droidian with Cutie Shell. Cutie Shell is still pre-alpha quality and it is not suitable for production environments. Keep in mind that Cutie Shell is not officially supported or endorsed by Droidian. This edition is maintained directly by Cutie Shell Community Project and you should report any bugs with these images at Cutie Shell Community Project before filing upstream."

--- a/v2/devices/perseus.yml
+++ b/v2/devices/perseus.yml
@@ -20,7 +20,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
 unlock:
   - "confirm_model"
   - "unlock"

--- a/v2/devices/sagit.yml
+++ b/v2/devices/sagit.yml
@@ -20,7 +20,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
 unlock:
   - "confirm_model"
   - "unlock"

--- a/v2/devices/santoni.yml
+++ b/v2/devices/santoni.yml
@@ -17,7 +17,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock"
+    link: "https://en.miui.com/unlock/download_en.html"
   support:
     title: "Support"
     description: "For details about Ubuntu Touch support for the Redmi 4X, please head over to the UBports forum thread."

--- a/v2/devices/violet.yml
+++ b/v2/devices/violet.yml
@@ -20,7 +20,7 @@ user_actions:
   unlock:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
-    link: "https://en.miui.com/unlock/"
+    link: "https://en.miui.com/unlock/download_en.html"
 unlock:
   - "confirm_model"
   - "unlock"


### PR DESCRIPTION
the original link now leads to empty page with response with an empty body

edited also on non-maintained devices

curl https://en.miui.com/unlock/ -I
HTTP/2 200
date: Wed, 17 Jun 2026 19:21:03 GMT
content-type: application/octet-stream
content-length: 0
cache-control: no-store
upload-time: 1646041284357
last-modified: Mon, 28 Feb 2022 09:41:24 GMT
x-xiaomi-meta-content-length: 0
x-xiaomi-storage-class: STANDARD
etag: "d41d8cd98f00b204e9800998ecf8427e"
content-md5: d41d8cd98f00b204e9800998ecf8427e
x-xiaomi-hash-crc64ecma: 0
x-xiaomi-request-id: c43bf0e9-90d9-9f56-0000-019ed707a63e access-control-allow-credentials: true
access-control-expose-headers: content-md5, upload-time, x-xiaomi-meta-content-length server: MonKing/3.14
xiaomi-security-center: if any vulnerability found, go https://sec.xiaomi.com