### PR TITLE
begonia: revert fastboot system flashing hack, update recovery

### DIFF
--- a/v2/devices/begonia.yml
+++ b/v2/devices/begonia.yml
@@ -4,15 +4,15 @@ formfactor: "phone"
 aliases: []
 doppelgangers: []
 user_actions:
+  recovery:
+    title: "Reboot to Recovery"
+    description: "With the device powered off, hold Volume Up + Power."
+    image: "phone_power_up"
+    button: true
   bootloader:
     title: "Reboot to Bootloader"
     description: "With the device powered off, hold Volume Down + Power."
     image: "phone_power_down"
-    button: true
-  boot:
-    title: "Boot the device"
-    description: "Power on the device."
-    image: "phone_power_up"
     button: true
   confirm_model:
     title: "Confirm your model"
@@ -21,13 +21,9 @@ user_actions:
     title: "OEM unlock"
     description: "If you haven't done so already, make sure to OEM unlock your device first."
     link: "https://en.miui.com/unlock/download_en.html"
-  adb_bug:
-    title: "Warning"
-    description: "This device is known to have problems with adb push, so the installer will flash latest stable image. Please switch to desired channel afterwards in System Settings."
 unlock:
   - "confirm_model"
   - "unlock"
-  - "adb_bug"
 handlers:
   bootloader_locked:
     actions:
@@ -73,10 +69,10 @@ operating_systems:
                   checksum:
                     sum: "7bcf9b85133b3e748ac72d27d0a3f58be9c1f6ac96c9c5b866b684b266dcc108"
                     algorithm: "sha256"
-                - url: "https://github.com/ubuntu-touch-begonia/ubuntu-touch-begonia/releases/download/20210810/recovery.img"
+                - url: "https://github.com/ubuntu-touch-begonia/ubuntu-touch-begonia/releases/download/20260713/recovery.img"
                   name: "recovery.img"
                   checksum:
-                    sum: "9facd6ab47459f85aab4ee1f43b261aac66af710bafbe3f4f2cea330e56fe8d1"
+                    sum: "5646073d2992d03a702be466c1203b09e732b5cf145b7a7c41e0ed8eb46a7144"
                     algorithm: "sha256"
                 - url: "https://github.com/ubuntu-touch-begonia/ubuntu-touch-begonia/releases/download/20210810/vbmeta.img"
                   name: "vbmeta.img"
@@ -86,20 +82,6 @@ operating_systems:
         condition:
           var: "bootstrap"
           value: true
-      - actions:
-          - core:download:
-              group: "Ubuntu Touch"
-              files:
-                - url: "https://github.com/ubuntu-touch-begonia/ubuntu-touch-begonia/releases/download/ota-19/system.zip"
-                  name: "system.zip"
-                  checksum:
-                    sum: "fff166da969228b6f9359a7c064710933397be6ad62efaae9162600027137341"
-                    algorithm: "sha256"
-                - url: "https://github.com/ubuntu-touch-begonia/ubuntu-touch-begonia/releases/download/ota-19/boot.img"
-                  name: "boot.img"
-                  checksum:
-                    sum: "fa92b082823be3b8527b81e720dc59835d13c8898fe513009f44285821e98d4f"
-                    algorithm: "sha256"
       - actions:
           - core:unpack:
               group: "firmware"
@@ -112,17 +94,14 @@ operating_systems:
           var: "bootstrap"
           value: true
       - actions:
-          - core:unpack:
-              group: "Ubuntu Touch"
-              files:
-                - archive: "system.zip"
-                  dir: "unpacked"
-      - actions:
           - adb:reboot:
               to_state: "bootloader"
         fallback:
           - core:user_action:
               action: "bootloader"
+        condition:
+          var: "bootstrap"
+          value: true
       - actions:
           - fastboot:format:
               partition: "userdata"
@@ -203,17 +182,19 @@ operating_systems:
           var: "bootstrap"
           value: true
       - actions:
-          - fastboot:flash:
-              partitions:
-                - partition: "boot"
-                  file: "boot.img"
-                  group: "Ubuntu Touch"
-                - partition: "system"
-                  file: "unpacked/system.img"
-                  group: "Ubuntu Touch"
-      - actions:
           - fastboot:reboot:
         fallback:
           - core:user_action:
-              action: "boot"
+              action: "recovery"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - systemimage:install:
+      - actions:
+          - adb:reboot:
+              to_state: "recovery"
+        fallback:
+          - core:user_action:
+              action: "recovery"
     slideshow: []


### PR DESCRIPTION
Revert 920a7efc, which worked around unreliable `adb push` by fastboot-flashing a prebuilt Ubuntu Touch 16.04 OTA-19 image.

Point recovery.img at the new 20260713 release URL, which has been updated to use the unified recovery and has `adb` fixed.