### PR TITLE
mimir: Add SailfishOS install option

### DIFF
--- a/v2/devices/mimir.yml
+++ b/v2/devices/mimir.yml
@@ -17,6 +17,11 @@ user_actions:
     title: "Reboot the device"
     description: "Hold down the power button until the device powers down. Then, release it briefly and hold it down again until the device boots."
     button: true
+  sfos_notice:
+    title: "SailfishOS: Notice"
+    description: "For additional information about the Volla device ports including known issues please visit the following URL."
+    link: "https://forum.sailfishos.org/t/the-single-volla-thread/22553"
+    button: true
 unlock: []
 handlers:
   bootloader_locked:
@@ -278,3 +283,143 @@ operating_systems:
       title: "EULA"
       description: "To proceed with the installation you have to confirm that you have read and understood the End User License Agreement (EULA) of Volla Systeme GmbH for the Volla OS and agree to it."
       link: "https://volla.online/en/eula/index.html"
+
+  - name: "SailfishOS"
+    prerequisites: []
+    compatible_installer: ">=0.9.2-beta"
+    options:
+      - var: "bootstrap"
+        name: "Bootstrap"
+        tooltip: "Flash system partitions using fastboot. Keep enabled if coming from non-Sailfish OS"
+        type: "checkbox"
+        value: true
+      - var: "wipe"
+        name: "Wipe Userdata"
+        tooltip: "Wipe personal data. *Required* on the first SailfishOS installation."
+        type: "checkbox"
+        value: true
+    steps:
+      - actions:
+          - core:user_action:
+              action: "sfos_notice"
+      - actions:
+          - core:download:
+              group: "SailfishOS"
+              files:
+                - url: "https://github.com/HelloVolla/sailfish-release-halium-mimir/releases/latest/download/SailfishOS-halium-mimir.7z"
+      - actions:
+          - core:unpack:
+              group: "SailfishOS"
+              files:
+                - archive: "SailfishOS-halium-mimir.7z"
+                  dir: "unpacked"
+
+      # Firmware setup (bootstrap)
+      - actions:
+          - core:download:
+              group: "firmware"
+              files:
+                - url: "https://volla.tech/filedump/volla-mimir-13.0-ubports-installer-bootstrap.zip"
+                  checksum:
+                    sum: "1d3aaa0e78834e9e6667c43c79ef748737b5264c0c6641917636240484be022c"
+                    algorithm: "sha256"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - core:unpack:
+              group: "firmware"
+              files:
+                - archive: "volla-mimir-13.0-ubports-installer-bootstrap.zip"
+                  dir: "unpacked"
+        condition:
+          var: "bootstrap"
+          value: true
+      - actions:
+          - adb:reboot:
+              to_state: "bootloader"
+        fallback:
+          - core:user_action:
+              action: "bootloader"
+      - actions:
+          - fastboot:set_active:
+              slot: "a"
+
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "preloader_a"
+                  file: "unpacked/preloader_tb8781p1_64.bin"
+                  group: "firmware"
+                - partition: "vbmeta_a"
+                  file: "unpacked/vbmeta.img"
+                  group: "firmware"
+                  flags: ["--disable-verity"]
+                - partition: "md1img_a"
+                  file: "unpacked/md1img.img"
+                  group: "firmware"
+                - partition: "spmfw_a"
+                  file: "unpacked/spmfw.img"
+                  group: "firmware"
+                - partition: "pi_img_a"
+                  file: "unpacked/pi_img.img"
+                  group: "firmware"
+                - partition: "dpm_a"
+                  file: "unpacked/dpm.img"
+                  group: "firmware"
+                - partition: "scp_a"
+                  file: "unpacked/scp.img"
+                  group: "firmware"
+                - partition: "sspm_a"
+                  file: "unpacked/sspm.img"
+                  group: "firmware"
+                - partition: "mcupm_a"
+                  file: "unpacked/mcupm.img"
+                  group: "firmware"
+                - partition: "gz_a"
+                  file: "unpacked/gz.img"
+                  group: "firmware"
+                - partition: "tee_a"
+                  file: "unpacked/tee.img"
+                  group: "firmware"
+                - partition: "csci"
+                  file: "unpacked/csci.ini"
+                  group: "firmware"
+                - partition: "logo"
+                  file: "unpacked/logo.bin"
+                  group: "firmware"
+        condition:
+          var: "bootstrap"
+          value: true
+
+      - actions:
+          - fastboot:flash:
+              partitions:
+                - partition: "boot_a"
+                  file: "unpacked/SailfishOS-halium-mimir/boot.img"
+                  group: "SailfishOS"
+                - partition: "vendor_boot_a"
+                  file: "unpacked/SailfishOS-halium-mimir/vendor_boot.img"
+                  group: "SailfishOS"
+                - partition: "dtbo_a"
+                  file: "unpacked/SailfishOS-halium-mimir/dtbo.img"
+                  group: "SailfishOS"
+                - partition: "lk_a"
+                  file: "unpacked/SailfishOS-halium-mimir/lk.img"
+                  group: "SailfishOS"
+                - partition: "super"
+                  file: "unpacked/SailfishOS-halium-mimir/super.img"
+                  group: "SailfishOS"
+      - actions:
+          - fastboot:format:
+              partition: "userdata"
+              type: "ext4"
+        condition:
+          var: "wipe"
+          value: true
+      - actions:
+          - fastboot:reboot:
+        fallback:
+          - core:user_action:
+              action: "boot"
+    slideshow: []


### PR DESCRIPTION
Adds a SailfishOS entry for the Volla Tablet. Verified against `release-testing-5.1.0.11-user1`.